### PR TITLE
Fix copy markdown button by serving raw markdown from GitHub

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -22,15 +22,16 @@ export default async function Page(props: {
     notFound()
 
   const MDX = page.data.body
+  const markdownUrl = page.url === '/docs' ? '/docs/index.mdx' : `${page.url}.mdx`
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
       <div className="flex flex-row gap-2 items-center border-b pb-6">
-        <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
+        <LLMCopyButton markdownUrl={markdownUrl} />
         <ViewOptions
-          markdownUrl={`${page.url}.mdx`}
+          markdownUrl={markdownUrl}
           githubUrl={`https://github.com/letstri/permix/blob/main/docs/content/docs/${page.path}`}
         />
       </div>

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -10,7 +10,7 @@ const config: NextConfig = {
     return [
       {
         source: '/docs/:path*.mdx',
-        destination: '/llms.mdx/:path*',
+        destination: 'https://raw.githubusercontent.com/letstri/permix/refs/heads/main/docs/content/docs/:path*.mdx',
       },
     ]
   },


### PR DESCRIPTION
Add Next.js rewrites to serve markdown files directly from GitHub raw URLs, fixing the copy markdown button functionality.