### PR TITLE
fix(elysia): relax checkHandler context type to support schema validation

### DIFF
--- a/permix/src/elysia/create-permix.test.ts
+++ b/permix/src/elysia/create-permix.test.ts
@@ -1,5 +1,5 @@
 import type { PermixDefinition } from '../core/create-permix'
-import { Elysia } from 'elysia'
+import { Elysia, t } from 'elysia'
 import { describe, expect, it } from 'vitest'
 import { createPermix } from './create-permix'
 
@@ -204,6 +204,32 @@ describe('createPermix', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body).toEqual({ success: true })
+  })
+
+  it('should typecheck with schema-validated query (regression #33)', async () => {
+    const app = new Elysia()
+      .derive(() => permix.derive({
+        post: {
+          create: true,
+          read: false,
+          update: false,
+        },
+        user: {
+          delete: false,
+        },
+      }))
+      .get('/posts', ({ query }) => ({ page: query.page }), {
+        query: t.Object({
+          page: t.Numeric({ default: 1 }),
+        }),
+        beforeHandle: permix.checkHandler('post', 'create'),
+      })
+
+    const response = await app.handle(new Request('http://localhost/posts?page=2'))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ page: 2 })
   })
 
   it('should dehydrate permissions', async () => {

--- a/permix/src/elysia/create-permix.ts
+++ b/permix/src/elysia/create-permix.ts
@@ -8,7 +8,7 @@ import { createTemplate } from '../core/template'
 import { pick } from '../utils'
 
 export interface ElysiaContext {
-  context: Context
+  context: { set: Context['set'], [key: string]: any }
 }
 
 export interface PermixOptions<T extends PermixDefinition> {
@@ -36,7 +36,7 @@ export function createPermix<Definition extends PermixDefinition>(
   })
 
   const checkHandler = <K extends keyof Definition>(...params: CheckFunctionParams<Definition, K>) => {
-    return async (context: Context & { permix: Pick<Permix<Definition>, 'check' | 'dehydrate'> }) => {
+    return async (context: { permix: Pick<Permix<Definition>, 'check' | 'dehydrate'>, set: Context['set'] }) => {
       if (!context.permix) {
         throw new Error('[Permix]: Instance not found. Please use the `setupMiddleware` function.')
       }


### PR DESCRIPTION
## Summary

- Fixes #33: `checkHandler` returned a function typed with `Context & { permix }`, forcing `query`/`params`/`body` to match Elysia's raw `Record<string, string>` shape. Routes that use Zod or TypeBox validation to transform these into non-string types failed to typecheck.
- Narrows the `checkHandler` parameter type to only the properties it actually uses (`permix` and `set`), using `Context['set']` from Elysia for the exact `set` shape (status/headers/redirect/cookie).
- Same relaxation applied to `ElysiaContext` so `onForbidden` callbacks no longer constrain the route context.

## Implementation (Option A from the issue)

`permix/src/elysia/create-permix.ts`:

```ts
const checkHandler = <K extends keyof Definition>(...params: CheckFunctionParams<Definition, K>) => {
  return async (context: { permix: Pick<Permix<Definition>, 'check' | 'dehydrate'>, set: Context['set'] }) => {
    // ...
  }
}
```

`Context['set']` is reused (not a hand-rolled `{ status?: any }`) so the type stays exact and tracks Elysia upstream changes.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm test` — all 185 tests pass (was 184 + 1 new regression test)
- [x] New regression test added: `should typecheck with schema-validated query (regression #33)` — uses `t.Numeric` to ensure `checkHandler` works with a route whose `query` is transformed into a numeric type

## Reproduction (now passes)

```ts
new Elysia()
  .get('/posts', ({ query }) => ({ page: query.page }), {
    query: t.Object({ page: t.Numeric({ default: 1 }) }),
    beforeHandle: permix.checkHandler('post', 'create'),
  })
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)