### PR TITLE
docs: support Permix checks in TanStack Start beforeLoad and loaders

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["run", "dev"],
       "cwd": "docs",
       "port": 3000
+    },
+    {
+      "name": "tanstack-start-example",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "dev", "--port", "3001"],
+      "cwd": "examples/tanstack-start",
+      "port": 3001
     }
   ]
 }

--- a/docs/content/docs/integrations/tanstack-start.mdx
+++ b/docs/content/docs/integrations/tanstack-start.mdx
@@ -227,10 +227,11 @@ export const getPermixState = createServerFn()
 The root route's `beforeLoad` runs before every child route's `beforeLoad` and `loader`, so hydrating there makes `context.permix` ready everywhere below it. Returning the state also puts it on the context for the components.
 
 ```tsx title="src/routes/__root.tsx"
-import { Outlet } from '@tanstack/react-router'
+import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 import { getPermixState } from '../lib/permix.server'
 import { Providers } from '../providers'
 
+// `RouterContext` from the previous step.
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: async ({ context }) => {
     const state = await getPermixState()

--- a/docs/content/docs/integrations/tanstack-start.mdx
+++ b/docs/content/docs/integrations/tanstack-start.mdx
@@ -7,7 +7,7 @@ description: Learn how to use Permix with TanStack Start
 
 Permix provides a dedicated integration for [TanStack Start](https://tanstack.com/start) through `permix/tanstack-start`. It exposes a `createPermix` factory that returns a **per-request** Permix instance backed by TanStack Start's [server request context](https://tanstack.com/start/latest/docs/framework/react/guide/middleware).
 
-You `setupMiddleware()` the rules once per request and `get()` them on the server inside **server functions** and **server routes** — without threading the instance through props. The client side reuses the React integration (`permix/react`) via `PermixProvider` + `PermixHydrate`.
+You `setupMiddleware()` the rules once per request and `get()` them on the server inside **server functions** and **server routes** — without threading the instance through props. A second instance lives on the **router context**, so `beforeLoad` and `loader` can check permissions isomorphically, and the same instance backs the React integration (`permix/react`) via `PermixProvider` + `PermixHydrate`.
 
 <Callout>
 Before getting started with the TanStack Start integration, make sure you've completed the initial setup steps in the [Quick Start](/docs/quick-start) guide. Familiarity with the [Hydration guide](/docs/guide/hydration) helps too.
@@ -122,11 +122,11 @@ export const Route = createFileRoute('/posts/$id')({
 })
 ```
 
-<Callout type="warn">
-Don't call `permix.get(context)` directly inside a route `loader` or `beforeLoad`. Those run **isomorphically** (on both server and client), and the `context` they receive is the [router context](https://tanstack.com/router/latest/docs/framework/react/guide/router-context) — not the server request context where `setupMiddleware()` stored the instance. Always do server checks inside a `createServerFn` (or a server route) so they execute on the server with access to the instance.
-</Callout>
-
 Use `get(context)` instead of `getOrThrow(context)` when you want a nullable value rather than a [`PermixNotFoundError`](/docs/guide/instance) if setup didn't run.
+
+<Callout type="warn">
+`permix.get(context)` only works where `context` is the **server request context** — server functions and server routes. A route `loader` or `beforeLoad` receives the [router context](https://tanstack.com/router/latest/docs/framework/react/guide/router-context) instead, and runs **isomorphically** on both server and client. To check permissions there, put an instance on the router context — see [Check in `beforeLoad` and loaders](#check-in-beforeload-and-loaders).
+</Callout>
 
 </Step>
 
@@ -162,12 +162,58 @@ const permix = createPermix<Definition>({
 
 <Step>
 
-## Send permissions to the client
+## Add Permix to the router context
 
-Use `dehydrate(context)` to serialize the request's permissions and hand them to a client provider. The server cannot send the Permix instance itself across the boundary — only the JSON state.
+`beforeLoad` and `loader` never see the server request context, but they do see the [router context](https://tanstack.com/router/latest/docs/framework/react/guide/router-context). Create a core Permix instance inside `getRouter()` and pass it there.
+
+`getRouter()` runs **once per request on the server** and **once per tab in the browser**, so this instance is request-scoped during SSR and a singleton in the browser — the same lifetime you want for the client cache.
+
+```tsx title="src/router.tsx"
+import type { PermissionsDefinition } from './lib/permix'
+import { createRouter as createTanStackRouter } from '@tanstack/react-router'
+import { createPermix } from 'permix'
+import { routeTree } from './routeTree.gen'
+
+export function getRouter() {
+  const permix = createPermix<PermissionsDefinition>()
+
+  return createTanStackRouter({
+    routeTree,
+    context: { permix },
+  })
+}
+```
+
+Type the context on the root route with `createRootRouteWithContext`:
+
+```tsx title="src/routes/__root.tsx"
+import type { Permix } from 'permix'
+import type { PermissionsDefinition } from '../lib/permix'
+import { createRootRouteWithContext } from '@tanstack/react-router'
+
+export interface RouterContext {
+  permix: Permix<PermissionsDefinition>
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
+  // ...
+})
+```
+
+<Callout type="warn">
+Typing the context is not enough on its own — the runtime value must be passed to `createTanStackRouter({ context })` too, otherwise `context.permix` is `undefined` in every route.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Hydrate it in the root route
+
+Use `dehydrate(context)` to serialize the request's permissions, then hydrate the router-context instance in the root route's `beforeLoad`. The server cannot send the instance itself across the boundary — only the JSON state.
 
 <Callout>
-Route loaders in TanStack Start are **isomorphic** — they run on both server and client. Since the Permix instance only exists in the server context, you must call `dehydrate()` inside a `createServerFn` to ensure it always executes on the server.
+`beforeLoad` and `loader` are **isomorphic** — they run on both server and client. Since the request-scoped instance only exists in the server context, `dehydrate()` must be called inside a `createServerFn` so it always executes on the server.
 </Callout>
 
 ```ts title="src/lib/permix.server.ts"
@@ -178,41 +224,49 @@ export const getPermixState = createServerFn()
   .handler(({ context }) => permix.dehydrate(context))
 ```
 
+The root route's `beforeLoad` runs before every child route's `beforeLoad` and `loader`, so hydrating there makes `context.permix` ready everywhere below it. Returning the state also puts it on the context for the components.
+
 ```tsx title="src/routes/__root.tsx"
-import { createRootRoute, Outlet } from '@tanstack/react-router'
+import { Outlet } from '@tanstack/react-router'
 import { getPermixState } from '../lib/permix.server'
 import { Providers } from '../providers'
 
-export const Route = createRootRoute({
-  loader: async () => ({ state: await getPermixState() }),
+export const Route = createRootRouteWithContext<RouterContext>()({
+  beforeLoad: async ({ context }) => {
+    const state = await getPermixState()
+
+    context.permix.hydrate(state)
+
+    return { state }
+  },
   component: RootComponent,
 })
 
 function RootComponent() {
-  const { state } = Route.useLoaderData()
+  const { permix, state } = Route.useRouteContext()
 
   return (
-    <Providers state={state}>
+    <Providers permix={permix} state={state}>
       <Outlet />
     </Providers>
   )
 }
 ```
 
+Pass the very same instance to `PermixProvider` so routes and components read one source of truth:
+
 ```tsx title="src/providers.tsx"
-import type { DehydratedState } from 'permix'
+import type { DehydratedState, Permix } from 'permix'
 import type { PermissionsDefinition } from './lib/permix'
-import { createPermix } from 'permix'
 import { PermixHydrate, PermixProvider } from 'permix/react'
 
-// One singleton per browser tab, reusing the same definition as the server.
-const permix = createPermix<PermissionsDefinition>()
-
 export function Providers({
+  permix,
   state,
   children,
 }: {
-  state: DehydratedState<any>
+  permix: Permix<PermissionsDefinition>
+  state: DehydratedState<PermissionsDefinition>
   children: React.ReactNode
 }) {
   return (
@@ -221,13 +275,41 @@ export function Providers({
     </PermixProvider>
   )
 }
-
-export { permix }
 ```
 
 <Callout type="warn">
-`hydrate()` restores the boolean state but does not flip `isReady` on its own — function-based rules are lost during serialization. If you need `isReady` on the client, call `permix.setup(...)` on the client too with the same shape. See the [Hydration guide](/docs/guide/hydration) for details.
+`hydrate()` restores the boolean state but does not flip `isReady` on its own — function-based rules are lost during serialization. If you need `isReady`, or rules that depend on check-time data (`update: post => post.authorId === userId`), call `permix.setup(...)` on the client too with the same shape. See the [Hydration guide](/docs/guide/hydration) for details.
 </Callout>
+
+</Step>
+
+<Step>
+
+## Check in `beforeLoad` and loaders
+
+With the instance hydrated on the router context, any route can guard itself without a dedicated server function. The check runs on the server during SSR and on the client on subsequent navigations.
+
+```tsx title="src/routes/dashboard.tsx"
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/dashboard')({
+  beforeLoad: ({ context }) => {
+    if (!context.permix.check('post.create')) {
+      throw redirect({ to: '/login' })
+    }
+  },
+  component: DashboardComponent,
+})
+```
+
+<Callout type="warn">
+This is a **UX guard**, not enforcement. The client can always call your server functions directly, so mirror every guard with `checkMiddleware()` (or a `getOrThrow(context).check()`) on the server.
+</Callout>
+
+Two limits are worth knowing:
+
+- Hydrated rules are plain booleans, so a data-dependent rule like `post.update` collapses to its no-data result. Checks that need the entity belong in a server function — or re-run `setup()` on the client with the full rules.
+- `check()` throws [`PermixNotReadyError`](/docs/guide/instance) when the instance has neither been hydrated nor set up, which is what you'll see if the root `beforeLoad` was skipped.
 
 </Step>
 
@@ -235,14 +317,24 @@ export { permix }
 
 ## Use on the client
 
-From any client component, import the singleton from `src/providers.tsx` and the hooks/components from `permix/react`:
+Read the instance off the router context and pass it to `usePermix`:
+
+```tsx title="src/lib/use-permix.ts"
+import { useRouteContext } from '@tanstack/react-router'
+import { usePermix as useReactPermix } from 'permix/react'
+
+export function usePermix() {
+  const { permix } = useRouteContext({ from: '__root__' })
+
+  return useReactPermix(permix)
+}
+```
 
 ```tsx title="src/components/edit-button.tsx"
-import { usePermix } from 'permix/react'
-import { permix } from '../providers'
+import { usePermix } from '../lib/use-permix'
 
 export function EditButton({ post }: { post: { id: string, authorId: string } }) {
-  const { check } = usePermix(permix)
+  const { check } = usePermix()
 
   if (!check('post.update', post)) {
     return null
@@ -289,11 +381,29 @@ permix.setupMiddleware(async ({ request }) => {
 
 </Step>
 
+<Step>
+
+## Example
+
+A runnable app wiring all of the above together lives [here](https://github.com/letstri/permix/tree/main/examples/tanstack-start).
+
+</Step>
+
 </Steps>
 
 ## How per-request isolation works
 
 `setupMiddleware` creates a fresh core instance per request and stores it on TanStack Start's server request context. All subsequent `get()` / `getOrThrow()` / `check()` calls within the same request share that one instance. Across concurrent requests, each gets its **own** instance — state never leaks between users.
+
+The router-context instance is separate, and isolated for the same reason: `getRouter()` is called once per request on the server, so each SSR render builds its own router with its own Permix instance. In the browser `getRouter()` runs once, so that instance doubles as the per-tab client cache.
+
+| | Server request context | Router context |
+|---|---|---|
+| Created by | `setupMiddleware()` | `getRouter()` |
+| Read with | `permix.get(context)` / `getOrThrow(context)` | `context.permix` |
+| Available in | server functions, server routes | `beforeLoad`, `loader`, components |
+| Rules | full, including function-based | hydrated booleans (until you `setup()` on the client) |
+| Trustworthy | yes — enforcement | no — UX only |
 
 ## API
 

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -6,7 +6,9 @@ Runnable demo of the [`permix/tanstack-start`](https://permix.letstri.dev/docs/i
 
 - **Per-request setup** — `src/start.ts` registers `permix.setupMiddleware()` globally so every request gets an isolated instance.
 - **Server checks** — server functions call `permix.getOrThrow(context)` / `checkMiddleware()`, invoked from route loaders.
-- **Client hydration** — the root loader dehydrates state via `getRootLoaderData()` and wraps the app in `PermixProvider` + `PermixHydrate`.
+- **Router context** — `src/router.tsx` puts a Permix instance on the router context; the root `beforeLoad` hydrates it with the server state.
+- **Route guards** — `/admin` calls `context.permix.check('post.delete')` in `beforeLoad`, no server function needed.
+- **Client hydration** — the same router-context instance backs `PermixProvider` + `PermixHydrate`.
 - **Role switching** — switch between guest, Alice, Bob, and admin to see permissions change.
 
 ## Run locally
@@ -25,13 +27,16 @@ Open [http://localhost:3000](http://localhost:3000).
 
 | File | Purpose |
 |------|---------|
-| `src/lib/permix.ts` | Permission definition and TanStack Start helper |
+| `src/lib/permix.ts` | Permission definition, TanStack Start helper, router-context instance |
 | `src/start.ts` | Global `setupMiddleware()` per request |
+| `src/router.tsx` | Puts the Permix instance on the router context |
 | `src/server/permix.ts` | `getRootLoaderData()` — dehydrate for the client |
 | `src/server/posts.ts` | Server functions with `getOrThrow(context)` checks and `checkMiddleware` |
+| `src/lib/use-permix.ts` | `usePermix()` reading the instance from the router context |
 | `src/providers.tsx` | React provider + client rule setup for function-based checks |
-| `src/routes/__root.tsx` | Root loader and hydration boundary |
+| `src/routes/__root.tsx` | Root `beforeLoad` — hydrates the router-context instance |
 | `src/routes/index.tsx` | Home page with server-side permission badges |
+| `src/routes/admin.tsx` | Route guarded by `context.permix.check()` in `beforeLoad` |
 | `src/routes/posts.$id.tsx` | Route guarded by `post.read` on the server |
 
 ## Docs

--- a/examples/tanstack-start/src/components/edit-button.tsx
+++ b/examples/tanstack-start/src/components/edit-button.tsx
@@ -1,9 +1,8 @@
 import type { Post } from '@/lib/permix'
-import { usePermix } from 'permix/react'
-import { permix } from '@/providers'
+import { usePermix } from '@/lib/use-permix'
 
 export function EditButton({ post }: { post: Post }) {
-  const { check } = usePermix(permix)
+  const { check } = usePermix()
 
   if (!check('post.update', post)) {
     return null

--- a/examples/tanstack-start/src/lib/permix.ts
+++ b/examples/tanstack-start/src/lib/permix.ts
@@ -1,4 +1,6 @@
-import type { Permix, ValidateDefinition } from 'permix'
+import type { Permix, Rules, ValidateDefinition } from 'permix'
+import type { Session } from '@/lib/auth'
+import { createPermix as createCorePermix } from 'permix'
 import { createPermix } from 'permix/tanstack-start'
 
 export interface Post {
@@ -26,3 +28,22 @@ export const adminTemplate = permix.template({
 export const guestTemplate = permix.template({
   post: { create: false, read: true, update: false, delete: false },
 })
+
+export function createRouterPermix(): PermixInstance {
+  return createCorePermix<PermissionsDefinition>()
+}
+
+export interface RouterContext {
+  permix: PermixInstance
+}
+
+export function createClientRules(session: Session | null): Rules<PermissionsDefinition> {
+  return {
+    post: {
+      create: !!session,
+      read: true,
+      update: post => post?.authorId === session?.userId,
+      delete: session?.role === 'admin',
+    },
+  }
+}

--- a/examples/tanstack-start/src/lib/use-permix.ts
+++ b/examples/tanstack-start/src/lib/use-permix.ts
@@ -1,0 +1,8 @@
+import { useRouteContext } from '@tanstack/react-router'
+import { usePermix as useReactPermix } from 'permix/react'
+
+export function usePermix() {
+  const { permix } = useRouteContext({ from: '__root__' })
+
+  return useReactPermix(permix)
+}

--- a/examples/tanstack-start/src/providers.tsx
+++ b/examples/tanstack-start/src/providers.tsx
@@ -7,18 +7,21 @@ import { createClientRules } from '@/lib/permix'
 
 function ClientRulesSetup({
   permix,
+  state,
   session,
   children,
 }: {
   permix: PermixInstance
+  state: DehydratedState<PermissionsDefinition>
   session: Session | null
   children: React.ReactNode
 }) {
   // `hydrate()` only restores booleans — `setup()` brings back the
-  // function-based `post.update` rule and flips `isReady()`.
+  // function-based `post.update` rule and flips `isReady()`. Depends on
+  // `state` so it re-runs after every re-hydration, not just on session change.
   useLayoutEffect(() => {
     permix.setup(createClientRules(session))
-  }, [permix, session])
+  }, [permix, state, session])
 
   return children
 }
@@ -37,7 +40,7 @@ export function Providers({
   return (
     <PermixProvider permix={permix}>
       <PermixHydrate state={state}>
-        <ClientRulesSetup permix={permix} session={session}>
+        <ClientRulesSetup permix={permix} state={state} session={session}>
           {children}
         </ClientRulesSetup>
       </PermixHydrate>

--- a/examples/tanstack-start/src/providers.tsx
+++ b/examples/tanstack-start/src/providers.tsx
@@ -1,38 +1,35 @@
 import type { DehydratedState } from 'permix'
 import type { Session } from '@/lib/auth'
-import type { PermissionsDefinition } from '@/lib/permix'
-import { createPermix } from 'permix'
+import type { PermissionsDefinition, PermixInstance } from '@/lib/permix'
 import { PermixHydrate, PermixProvider } from 'permix/react'
 import { useLayoutEffect } from 'react'
-
-const permix = createPermix<PermissionsDefinition>()
+import { createClientRules } from '@/lib/permix'
 
 function ClientRulesSetup({
+  permix,
   session,
   children,
 }: {
+  permix: PermixInstance
   session: Session | null
   children: React.ReactNode
 }) {
+  // `hydrate()` only restores booleans — `setup()` brings back the
+  // function-based `post.update` rule and flips `isReady()`.
   useLayoutEffect(() => {
-    permix.setup({
-      post: {
-        create: !!session,
-        read: true,
-        update: post => post?.authorId === session?.userId,
-        delete: session?.role === 'admin',
-      },
-    })
-  }, [session])
+    permix.setup(createClientRules(session))
+  }, [permix, session])
 
   return children
 }
 
 export function Providers({
+  permix,
   state,
   session,
   children,
 }: {
+  permix: PermixInstance
   state: DehydratedState<PermissionsDefinition>
   session: Session | null
   children: React.ReactNode
@@ -40,10 +37,10 @@ export function Providers({
   return (
     <PermixProvider permix={permix}>
       <PermixHydrate state={state}>
-        <ClientRulesSetup session={session}>{children}</ClientRulesSetup>
+        <ClientRulesSetup permix={permix} session={session}>
+          {children}
+        </ClientRulesSetup>
       </PermixHydrate>
     </PermixProvider>
   )
 }
-
-export { permix }

--- a/examples/tanstack-start/src/routeTree.gen.ts
+++ b/examples/tanstack-start/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PostsIdRouteImport } from './routes/posts.$id'
 
+const AdminRoute = AdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +31,43 @@ const PostsIdRoute = PostsIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/posts/$id': typeof PostsIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/posts/$id': typeof PostsIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin': typeof AdminRoute
   '/posts/$id': typeof PostsIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/posts/$id'
+  fullPaths: '/' | '/admin' | '/posts/$id'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/posts/$id'
-  id: '__root__' | '/' | '/posts/$id'
+  to: '/' | '/admin' | '/posts/$id'
+  id: '__root__' | '/' | '/admin' | '/posts/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminRoute: typeof AdminRoute
   PostsIdRoute: typeof PostsIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminRoute: AdminRoute,
   PostsIdRoute: PostsIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/examples/tanstack-start/src/router.tsx
+++ b/examples/tanstack-start/src/router.tsx
@@ -1,9 +1,14 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
+import { createRouterPermix } from '@/lib/permix'
 import { routeTree } from './routeTree.gen'
 
 export function getRouter() {
+  // One instance per request on the server, one per tab in the browser.
+  const permix = createRouterPermix()
+
   const router = createTanStackRouter({
     routeTree,
+    context: { permix },
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,

--- a/examples/tanstack-start/src/routes/__root.tsx
+++ b/examples/tanstack-start/src/routes/__root.tsx
@@ -1,12 +1,13 @@
+import type { RouterContext } from '@/lib/permix'
 import { TanStackDevtools } from '@tanstack/react-devtools'
-import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
+import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { Providers } from '@/providers'
 import { getRootLoaderData } from '@/server/permix'
 
 import appCss from '../styles.css?url'
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
       {
@@ -27,16 +28,22 @@ export const Route = createRootRoute({
       },
     ],
   }),
-  loader: () => getRootLoaderData(),
+  beforeLoad: async ({ context }) => {
+    const data = await getRootLoaderData()
+
+    context.permix.hydrate(data.state)
+
+    return data
+  },
   component: RootComponent,
   shellComponent: RootDocument,
 })
 
 function RootComponent() {
-  const { state, session } = Route.useLoaderData()
+  const { permix, state, session } = Route.useRouteContext()
 
   return (
-    <Providers state={state} session={session}>
+    <Providers permix={permix} state={state} session={session}>
       <Outlet />
     </Providers>
   )

--- a/examples/tanstack-start/src/routes/admin.tsx
+++ b/examples/tanstack-start/src/routes/admin.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute, Link, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/admin')({
+  beforeLoad: ({ context }) => {
+    if (!context.permix.check('post.delete')) {
+      throw redirect({ to: '/' })
+    }
+  },
+  component: AdminPage,
+})
+
+function AdminPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-6 py-10">
+      <Link
+        to="/"
+        className="text-sm font-medium text-zinc-600 hover:text-zinc-900"
+      >
+        ← Back to posts
+      </Link>
+
+      <article className="rounded-xl border border-zinc-200 bg-white p-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin area</h1>
+        <p className="mt-4 text-sm text-zinc-600">
+          This route is guarded by
+          {' '}
+          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs">
+            context.permix.check(&apos;post.delete&apos;)
+          </code>
+          {' '}
+          inside
+          {' '}
+          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs">beforeLoad</code>
+          . Any role other than admin is redirected back to the home page.
+        </p>
+      </article>
+    </main>
+  )
+}

--- a/examples/tanstack-start/src/routes/index.tsx
+++ b/examples/tanstack-start/src/routes/index.tsx
@@ -3,33 +3,18 @@ import { CreatePostForm } from '@/components/create-post-form'
 import { EditButton } from '@/components/edit-button'
 import { PermissionBadge } from '@/components/permission-badge'
 import { RoleSwitcher } from '@/components/role-switcher'
-import { getRootLoaderData } from '@/server/permix'
+import { usePermix } from '@/lib/use-permix'
 import { getHomePageData } from '@/server/posts'
 
 export const Route = createFileRoute('/')({
-  loader: async () => {
-    const [rootData, homeData] = await Promise.all([
-      getRootLoaderData(),
-      getHomePageData(),
-    ])
-
-    return {
-      ...rootData,
-      ...homeData,
-    }
-  },
+  loader: () => getHomePageData(),
   component: Home,
 })
 
 function Home() {
-  const {
-    session,
-    role,
-    posts,
-    canCreate,
-    canReadFirst,
-    postChecks,
-  } = Route.useLoaderData()
+  const { session, role } = Route.useRouteContext()
+  const { posts, canCreate, canReadFirst, postChecks } = Route.useLoaderData()
+  const { check } = usePermix()
 
   return (
     <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-6 py-10">
@@ -79,6 +64,34 @@ function Home() {
             label="post.read (any post)"
             allowed={canReadFirst}
           />
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-zinc-200 bg-white p-5">
+        <h2 className="text-lg font-medium">Route guard in beforeLoad</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs">/admin</code>
+          {' '}
+          calls
+          {' '}
+          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs">
+            context.permix.check(&apos;post.delete&apos;)
+          </code>
+          {' '}
+          in
+          {' '}
+          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs">beforeLoad</code>
+          {' '}
+          — no server function involved. Only the admin role gets in.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <PermissionBadge label="post.delete" allowed={check('post.delete')} />
+          <Link
+            to="/admin"
+            className="rounded-lg border border-zinc-300 px-3 py-1.5 text-sm font-medium hover:bg-zinc-100"
+          >
+            Open /admin
+          </Link>
         </div>
       </section>
 

--- a/permix/skills/permix/references/frontend.md
+++ b/permix/skills/permix/references/frontend.md
@@ -190,6 +190,8 @@ Run client `permix.setup(...)` where you restore the session (e.g. after `Permix
 
 Use framework helpers from `permix/next` or `permix/tanstack-start` when available — they wire dehydrate/hydrate into the framework data flow.
 
+In TanStack Start, `permix.get(context)` only works in server functions and server routes. To check inside `beforeLoad`/`loader`, put a core instance on the **router context** in `getRouter()` (`context: { permix }`), type it with `createRootRouteWithContext`, hydrate it in the root route's `beforeLoad`, then call `context.permix.check(...)` in any child route. Passing only the context type without the runtime value leaves `context.permix` undefined.
+
 Docs:
 
 - https://permix.letstri.dev/docs/integrations/next


### PR DESCRIPTION
Closes #46

## Problem

The TanStack Start docs told users to type `permix` into the router context with `createRootRouteWithContext`, but never passed the runtime value to `createTanStackRouter`. As reported in #46, `context.permix` was therefore `undefined` in every `beforeLoad` and `loader`.

The previous fix went the other way: a callout telling users *not* to check permissions in loaders at all, and to wrap every check in a `createServerFn`. [@AhmedBaset's suggestion in the thread](https://github.com/letstri/permix/issues/46#issuecomment-4879691629) is nicer, so this implements that instead.

## Approach

Two instances, each with a clear job:

| | Server request context | Router context |
|---|---|---|
| Created by | `setupMiddleware()` | `getRouter()` |
| Read with | `permix.get(context)` | `context.permix` |
| Available in | server functions, server routes | `beforeLoad`, `loader`, components |
| Rules | full, including function-based | hydrated booleans |
| Trustworthy | yes — enforcement | no — UX only |

The router-context instance is created inside `getRouter()`, which runs once per request on the server and once per tab in the browser — so it is request-scoped during SSR and doubles as the client cache. The root route's `beforeLoad` hydrates it from a `createServerFn`, which makes it ready before every child route runs. The same instance is then handed to `PermixProvider`, so routes and components share one source of truth instead of a separate module-level singleton.

## Changes

No library API changes — this is wiring on top of the existing `dehydrate`/`hydrate`.

**Docs** (`docs/content/docs/integrations/tanstack-start.mdx`)

- Replaced the "don't check in loaders" callout with a pointer to the router-context pattern.
- Three new steps: add Permix to the router context, hydrate it in the root route, check in `beforeLoad`/loaders.
- Called out the exact trap from the issue — typing the context without passing the runtime value leaves `context.permix` undefined.
- Documented the two limits honestly: hydrated rules are plain booleans (so data-dependent rules like `post.update` collapse), and these guards are UX only, not enforcement.

**Example** (`examples/tanstack-start`)

- `router.tsx` creates the instance and passes `context: { permix }`.
- `__root.tsx` uses `createRootRouteWithContext` and hydrates in `beforeLoad`.
- New `/admin` route guarded entirely by `context.permix.check('post.delete')` in `beforeLoad`.
- `providers.tsx` takes the router-context instance instead of creating its own singleton.
- New `usePermix()` helper in `lib/use-permix.ts` that reads the instance off the route context.

**Skill** (`permix/skills/permix/references/frontend.md`) — short note on the pattern so agents don't reproduce the broken wiring.

## Verification

Ran the example in a browser:

- Alice clicks `/admin` → redirected to `/` (client-side guard on navigation).
- Direct hit on `/admin` as Alice or guest → redirected during SSR.
- Admin role → `/admin` renders.
- No console errors, no hydration mismatch.

`pnpm test` (298 tests), `pnpm run check-types` (14/14 packages), and `pnpm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
