### PR TITLE
feat: expose createSetupHandler for TanStack Start client bundle pruning

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["run", "dev"],
       "cwd": "docs",
       "port": 3000
+    },
+    {
+      "name": "tanstack-start-example",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "dev", "--port", "3001"],
+      "cwd": "examples/tanstack-start",
+      "port": 3001
     }
   ]
 }

--- a/docs/content/docs/integrations/tanstack-start.mdx
+++ b/docs/content/docs/integrations/tanstack-start.mdx
@@ -84,6 +84,45 @@ export const startInstance = createStart(() => ({
 You can also attach `setupMiddleware()` to a specific server route's `middleware` array instead of registering it globally, if only some routes need permissions.
 </Callout>
 
+### Server-only imports in the setup callback
+
+TanStack Start strips server code from the client bundle by rewriting `createMiddleware().server(...)` calls it finds **in your source files**. `setupMiddleware()` makes that call inside the Permix package, so the compiler never sees a `.server()` boundary in your module — the setup callback and everything it imports stay in the client graph.
+
+With plain isomorphic rules that's harmless. But as soon as the callback pulls in server-only dependencies — an auth library, a database client, `node:` builtins — they leak into the browser and fail at runtime:
+
+- `Buffer is not defined`
+- `Module "events" has been externalized for browser compatibility`
+- database drivers appearing in the client bundle
+
+When the callback needs server-only imports, write the `.server()` boundary yourself and pass in `createSetupHandler()` — the same setup logic, but placed where the compiler can strip it:
+
+```ts title="src/start.ts"
+import { createMiddleware, createStart } from '@tanstack/react-start'
+import { auth } from './lib/auth' // server-only: stays out of the client bundle
+import { permix } from './lib/permix'
+
+const permixMiddleware = createMiddleware().server(
+  permix.createSetupHandler(async ({ request }) => {
+    const session = await auth.api.getSession({ headers: request.headers })
+
+    return {
+      post: {
+        create: !!session,
+        read: true,
+        update: post => post?.authorId === session?.userId,
+        delete: session?.role === 'admin',
+      },
+    }
+  }),
+)
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [permixMiddleware],
+}))
+```
+
+`createSetupHandler()` accepts exactly what `setupMiddleware()` accepts — a rules object or a callback receiving the `request` — and produces the same request-scoped instance, hooks included. `checkMiddleware()` is unaffected: it never closes over your setup imports.
+
 </Step>
 
 <Step>
@@ -304,6 +343,7 @@ Returns an object with the following methods:
 | Method | Description |
 |---|---|
 | `setupMiddleware(rules \| ({ request }) => rules)` | A **request** middleware that creates a per-request instance and runs `setup()`. Register it globally in `src/start.ts` or on a server route. |
+| `createSetupHandler(rules \| ({ request }) => rules)` | The server handler behind `setupMiddleware`, for passing to your own `createMiddleware().server(...)`. Use when the callback has [server-only imports](#server-only-imports-in-the-setup-callback). |
 | `checkMiddleware(...args)` | A **function** middleware that enforces a permission check before a server function's handler. |
 | `get(context)` | Read the request-scoped [`Permix<D>`](/docs/guide/instance) instance from a context object, or `null` if missing. |
 | `getOrThrow(context)` | Like `get`, but throws `PermixNotFoundError` when the instance is missing. |

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -4,7 +4,7 @@ Runnable demo of the [`permix/tanstack-start`](https://permix.letstri.dev/docs/i
 
 ## What it shows
 
-- **Per-request setup** — `src/start.ts` registers `permix.setupMiddleware()` globally so every request gets an isolated instance.
+- **Per-request setup** — `src/start.ts` registers a global request middleware built with `createMiddleware().server(permix.createSetupHandler(...))`, so every request gets an isolated instance and the setup callback (with its server-only imports) is stripped from the client bundle.
 - **Server checks** — server functions call `permix.getOrThrow(context)` / `checkMiddleware()`, invoked from route loaders.
 - **Client hydration** — the root loader dehydrates state via `getRootLoaderData()` and wraps the app in `PermixProvider` + `PermixHydrate`.
 - **Role switching** — switch between guest, Alice, Bob, and admin to see permissions change.
@@ -26,7 +26,7 @@ Open [http://localhost:3000](http://localhost:3000).
 | File | Purpose |
 |------|---------|
 | `src/lib/permix.ts` | Permission definition and TanStack Start helper |
-| `src/start.ts` | Global `setupMiddleware()` per request |
+| `src/start.ts` | Per-request setup via `createSetupHandler()` in an app-owned `.server()` boundary |
 | `src/server/permix.ts` | `getRootLoaderData()` — dehydrate for the client |
 | `src/server/posts.ts` | Server functions with `getOrThrow(context)` checks and `checkMiddleware` |
 | `src/providers.tsx` | React provider + client rule setup for function-based checks |

--- a/examples/tanstack-start/src/start.ts
+++ b/examples/tanstack-start/src/start.ts
@@ -1,28 +1,34 @@
-import { createStart } from '@tanstack/react-start'
+import { createMiddleware, createStart } from '@tanstack/react-start'
 import { getSessionFromRequest } from '@/lib/auth'
 import { adminTemplate, guestTemplate, permix } from '@/lib/permix'
 
+// The `.server()` boundary lives in app code so TanStack Start strips the
+// callback — and its server-only imports like `@/lib/auth` — from the client
+// bundle. `permix.setupMiddleware(...)` would hide that boundary inside the
+// library, leaking the imports to the client.
+const permixMiddleware = createMiddleware().server(
+  permix.createSetupHandler(async ({ request }) => {
+    const session = getSessionFromRequest(request)
+
+    if (!session) {
+      return guestTemplate()
+    }
+
+    if (session.role === 'admin') {
+      return adminTemplate()
+    }
+
+    return {
+      post: {
+        create: true,
+        read: true,
+        update: post => post?.authorId === session.userId,
+        delete: false,
+      },
+    }
+  }),
+)
+
 export const startInstance = createStart(() => ({
-  requestMiddleware: [
-    permix.setupMiddleware(async ({ request }: { request: Request }) => {
-      const session = getSessionFromRequest(request)
-
-      if (!session) {
-        return guestTemplate()
-      }
-
-      if (session.role === 'admin') {
-        return adminTemplate()
-      }
-
-      return {
-        post: {
-          create: true,
-          read: true,
-          update: post => post?.authorId === session.userId,
-          delete: false,
-        },
-      }
-    }),
-  ],
+  requestMiddleware: [permixMiddleware],
 }))

--- a/permix/skills/permix/references/frontend.md
+++ b/permix/skills/permix/references/frontend.md
@@ -190,6 +190,8 @@ Run client `permix.setup(...)` where you restore the session (e.g. after `Permix
 
 Use framework helpers from `permix/next` or `permix/tanstack-start` when available — they wire dehydrate/hydrate into the framework data flow.
 
+TanStack Start bundle caveat: if the `setupMiddleware()` callback imports server-only code (auth library, DB client, `node:` builtins), those imports leak into the client bundle — Start only strips `.server()` bodies it sees in app source, not the one hidden inside the library. Use `createMiddleware().server(permix.createSetupHandler(callback))` in `src/start.ts` instead; same behavior, but the boundary is visible to the compiler and the callback gets pruned.
+
 Docs:
 
 - https://permix.letstri.dev/docs/integrations/next

--- a/permix/src/tanstack-start/permix.test.ts
+++ b/permix/src/tanstack-start/permix.test.ts
@@ -123,6 +123,69 @@ describe('tanstack-start createPermix', () => {
     expect(permix.getOrThrow(run.received.context).check('post.create')).toBe(true)
   })
 
+  describe('createSetupHandler', () => {
+    it('returns a handler usable inside an app-owned server boundary', async () => {
+      const permix = createPermix<PermissionsDefinition>()
+
+      const handler = permix.createSetupHandler(async ({ request }) => ({
+        post: {
+          create: new URL(request.url).searchParams.get('admin') === '1',
+          read: true,
+        },
+      }))
+
+      let received: Record<string | symbol, unknown> = {}
+      await handler({
+        request: new Request('http://localhost/?admin=1'),
+        next: async (arg) => {
+          received = arg.context
+          return arg
+        },
+      })
+
+      expect(permix.getOrThrow(received).check('post.create')).toBe(true)
+    })
+
+    it('accepts a plain rules object', async () => {
+      const permix = createPermix<PermissionsDefinition>()
+      const handler = permix.createSetupHandler({ post: { create: true, read: false } })
+
+      let received: Record<string | symbol, unknown> = {}
+      await handler({
+        request: new Request('http://localhost'),
+        next: async (arg) => {
+          received = arg.context
+          return arg
+        },
+      })
+
+      const instance = permix.getOrThrow(received)
+      expect(instance.check('post.create')).toBe(true)
+      expect(instance.check('post.read')).toBe(false)
+    })
+
+    it('fires factory-level check hooks like setupMiddleware does', async () => {
+      const permix = createPermix<PermissionsDefinition>()
+      const onCheck = vi.fn()
+      permix.hook('check', onCheck)
+
+      const handler = permix.createSetupHandler({ post: { create: true, read: true } })
+
+      let received: Record<string | symbol, unknown> = {}
+      await handler({
+        request: new Request('http://localhost'),
+        next: async (arg) => {
+          received = arg.context
+          return arg
+        },
+      })
+
+      permix.getOrThrow(received).check('post.create')
+
+      expect(onCheck).toHaveBeenCalledWith({ path: 'post.create', data: undefined })
+    })
+  })
+
   describe('get / getOrThrow', () => {
     it('returns the instance from context', () => {
       const permix = createPermix<PermissionsDefinition>()

--- a/permix/src/tanstack-start/permix.ts
+++ b/permix/src/tanstack-start/permix.ts
@@ -12,6 +12,16 @@ export interface SetupContext {
   request: Request
 }
 
+/**
+ * The subset of TanStack Start's request middleware server options that
+ * {@link createSetupHandler} needs. Kept structural so the handler stays
+ * assignable across TanStack Start versions (peer dependency is `>=1`).
+ */
+export interface SetupHandlerContext {
+  request: Request
+  next: (options: { context: Record<string | symbol, unknown> }) => any
+}
+
 export interface MiddlewareContext {
   // eslint-disable-next-line ts/no-empty-object-type
   next: FunctionMiddlewareServerNextFn<{}, unknown, undefined>
@@ -60,16 +70,40 @@ function buildPermix<D extends Definition>(
   }
 
   /**
-   * TanStack Start middleware that creates a request-scoped Permix instance,
-   * calls `setup()` with the resolved rules, and stores it in the server context.
+   * Build the server handler used by {@link setupMiddleware}, for passing to
+   * your own `createMiddleware().server(...)` call.
    *
-   * Register it globally via `createStart({ requestMiddleware: [...] })` so it
-   * runs for every request, or attach it to specific server routes.
+   * Prefer `setupMiddleware()` unless the callback reaches for server-only
+   * imports (a database client, an auth library, `node:` builtins). TanStack
+   * Start strips `.server()` bodies from the client bundle by matching
+   * `createMiddleware().server(...)` **in your own source**. It cannot see the
+   * `.server()` call hidden inside `setupMiddleware()`, so those imports stay
+   * in the client graph and surface as `Buffer is not defined` or externalized
+   * `node:` module warnings in the browser.
+   *
+   * Writing the `.server()` boundary yourself puts the callback where the
+   * compiler can strip it.
+   *
+   * @example
+   * ```ts
+   * import { createMiddleware } from '@tanstack/react-start'
+   * import { auth } from './lib/auth'
+   * import { permix } from './lib/permix'
+   *
+   * export const permixMiddleware = createMiddleware().server(
+   *   permix.createSetupHandler(async ({ request }) => {
+   *     const session = await auth.api.getSession({ headers: request.headers })
+   *     return { post: { create: !!session, read: true } }
+   *   }),
+   * )
+   * ```
+   *
+   * @link https://permix.letstri.dev/docs/integrations/tanstack-start#server-only-imports-in-the-setup-callback
    */
-  function setupMiddleware(
+  function createSetupHandler(
     callbackOrRules: ((context: SetupContext) => MaybePromise<Rules<D>>) | Rules<D>,
   ) {
-    return createMiddleware().server(async ({ next, request }) => {
+    return async ({ next, request }: SetupHandlerContext): Promise<any> => {
       const rules = typeof callbackOrRules === 'function'
         ? await callbackOrRules({ request })
         : callbackOrRules
@@ -77,7 +111,23 @@ function buildPermix<D extends Definition>(
       const instance = createPermixCore<D>(rules)
       instance.hook('check', context => hooks.callHook('check', context))
       return next({ context: { [resolveKey()]: instance } })
-    })
+    }
+  }
+
+  /**
+   * TanStack Start middleware that creates a request-scoped Permix instance,
+   * calls `setup()` with the resolved rules, and stores it in the server context.
+   *
+   * Register it globally via `createStart({ requestMiddleware: [...] })` so it
+   * runs for every request, or attach it to specific server routes.
+   *
+   * If the callback imports server-only code, use {@link createSetupHandler}
+   * instead so TanStack Start can strip it from the client bundle.
+   */
+  function setupMiddleware(
+    callbackOrRules: ((context: SetupContext) => MaybePromise<Rules<D>>) | Rules<D>,
+  ) {
+    return createMiddleware().server(createSetupHandler(callbackOrRules))
   }
 
   /**
@@ -124,6 +174,7 @@ function buildPermix<D extends Definition>(
 
   return {
     setupMiddleware,
+    createSetupHandler,
     checkMiddleware,
     get,
     getOrThrow,


### PR DESCRIPTION
Closes #49

## Problem

As reported in #49, server-only imports used inside the `permix.setupMiddleware()` callback (Better Auth, Prisma, `node:` builtins) leak into the client bundle and fail in the browser with errors like `Buffer is not defined`.

Verified the reporter's mechanism against the TanStack Start compiler (`@tanstack/start-plugin-core`): the compiler prunes server code by finding `createMiddleware().server(...)` method chains **in app source** and stripping the `.server()` call on the client build, after which dead-code elimination drops the callback's imports. `setupMiddleware()` makes that call inside the permix package, so the app module shows no strippable boundary — the callback closure and everything it imports stay in the client graph.

Reproduced on our own example: `examples/tanstack-start`'s client bundle contained `lib/auth` runtime code before this change. Its auth module happens to be browser-safe, so the leak was invisible — but any real app swapping in Better Auth or Prisma hits the reported errors.

Also considered teaching the compiler about `setupMiddleware` via Start's `compilerTransforms` API, but that's plugin-config-level (`TanStackStartCoreOptions`) — a library can't register one. The issue's `createSetupHandler` proposal is the right fix.

## Change

New `createSetupHandler(rules | ({ request }) => rules)` on the TanStack Start factory — the exact server handler `setupMiddleware()` used inline, now exposed so apps can own the `.server()` boundary:

```ts
const permixMiddleware = createMiddleware().server(
  permix.createSetupHandler(async ({ request }) => {
    const session = await auth.api.getSession({ headers: request.headers })
    return { /* rules */ }
  }),
)
```

`setupMiddleware()` now delegates to it, so behavior is identical by construction — same rules resolution, per-request instance creation, and factory-level hook wiring. `setupMiddleware()` remains the documented default for callbacks without server-only imports.

The handler is typed via a minimal structural `SetupHandlerContext` instead of Start's version-specific generics, since the peer dependency range is `>=1`.

- **Example** switches `src/start.ts` to the new pattern.
- **Docs** gain a "Server-only imports in the setup callback" section (symptoms, cause, fix) and an API table row.
- **Skill** (`references/frontend.md`) gets the caveat so agents don't generate the leaky wiring.
- **Tests**: callback + request resolution, plain rules object, factory-level `check` hooks firing through the exposed handler.

## Verification

- Client bundle grep before/after: `lib/auth` markers present with `setupMiddleware` + callback, absent with `createSetupHandler` in an app-owned `.server()`.
- Ran the example in a browser: alice gets owner-scoped `post.update`, admin gets everything — handler behavior identical to `setupMiddleware`, no console errors.
- Side effect: the example's long-standing `start.ts` TS2322 (`AnyRequestMiddleware` variance mismatch on the library-returned middleware) is gone — the app-owned `createMiddleware()` chain produces the exact expected type, and the example now typechecks clean.
- 301 tests, 14/14 package typechecks, lint, and `skills:stale` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)