### PR TITLE
feat: initialize Next.js Permix from a request-scoped rules resolver

### DIFF
--- a/.github/scripts/select-react-catalog.mjs
+++ b/.github/scripts/select-react-catalog.mjs
@@ -1,0 +1,17 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const react = process.env.REACT
+const reactTypes = process.env.REACT_TYPES
+const reactDomTypes = process.env.REACT_DOM_TYPES
+
+if (!react || !reactTypes || !reactDomTypes) {
+  throw new Error('REACT, REACT_TYPES, and REACT_DOM_TYPES must be set')
+}
+
+const yaml = readFileSync('pnpm-workspace.yaml', 'utf-8')
+  .replace(/^( {2}react: ).+$/m, `$1${react}`)
+  .replace(/^( {2}react-dom: ).+$/m, `$1${react}`)
+  .replace(/^( {2}'@types\/react': ).+$/m, `$1${reactTypes}`)
+  .replace(/^( {2}'@types\/react-dom': ).+$/m, `$1${reactDomTypes}`)
+
+writeFileSync('pnpm-workspace.yaml', yaml)

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -16,15 +16,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.5.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/next-integration.yml
+++ b/.github/workflows/next-integration.yml
@@ -1,0 +1,36 @@
+name: Next Integration
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  next-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @permix/next-integration exec playwright install chromium --with-deps
+
+      - name: Build Permix and run Next fixtures
+        run: pnpm test:next

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 24
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm i --frozen-lockfile
       - run: pnpm run lint

--- a/.github/workflows/react-compatibility.yml
+++ b/.github/workflows/react-compatibility.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Install pinned Permix dependencies
         if: matrix.pin
-        run: pnpm install --filter permix --no-frozen-lockfile
+        # Catalog pin is workspace-wide; docs/fumadocs still declare React 19 peers.
+        run: pnpm install --filter permix --no-frozen-lockfile --config.strictPeerDependencies=false
 
       - name: Install dependencies
         if: ${{ !matrix.pin }}

--- a/.github/workflows/react-compatibility.yml
+++ b/.github/workflows/react-compatibility.yml
@@ -1,0 +1,61 @@
+name: React Compatibility
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  react-compatibility:
+    name: React ${{ matrix.react }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - react: '18.3.1'
+            react-types: '18.3.23'
+            react-dom-types: '18.3.7'
+            pin: true
+          - react: '19.2.6'
+            react-types: '19.2.15'
+            react-dom-types: '19.2.3'
+            pin: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Pin React catalog versions
+        if: matrix.pin
+        env:
+          REACT: ${{ matrix.react }}
+          REACT_TYPES: ${{ matrix.react-types }}
+          REACT_DOM_TYPES: ${{ matrix.react-dom-types }}
+        run: node .github/scripts/select-react-catalog.mjs
+
+      - name: Install pinned Permix dependencies
+        if: matrix.pin
+        run: pnpm install --filter permix --no-frozen-lockfile
+
+      - name: Install dependencies
+        if: ${{ !matrix.pin }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Test React adapter
+        run: pnpm --filter permix exec vitest run src/react
+
+      - name: Build
+        run: pnpm --filter permix build

--- a/.github/workflows/types-check.yml
+++ b/.github/workflows/types-check.yml
@@ -16,21 +16,52 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.5.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm run build
-
       - name: Check types
         run: pnpm run check-types
+
+  typescript-compatibility:
+    name: TypeScript ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: '5.9.3'
+            script: type-check:compat:5.9
+          - version: '6.0.2'
+            script: type-check:compat:6
+          - version: '7.0.2'
+            script: type-check:compat:7
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check source and published package
+        run: pnpm --filter permix ${{ matrix.script }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 .pnpm-store
+.turbo

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .DS_Store
 .pnpm-store
 .turbo
+permix/test/next/.scratch
+permix/test/next/playwright-report
+permix/test/next/test-results

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
-  }
+  },
+  "js/ts.experimental.useTsgo": true,
+  "js/ts.tsdk.path": "./node_modules/typescript",
+  "typescript.preferences.preferTypeOnlyAutoImports": true
 }

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -166,6 +166,7 @@ const canUpdateComment = permix.check('comment.update', comment)
 What are the benefits of using Permix?
 
 - 100% type-safe without writing TypeScript (except for initialization)
+- Requires TypeScript 5.9 or newer (5.9, 6, and 7 are supported)
 - Single source of truth for your entire app
 - Perfect match for TypeScript monorepos
 - Zero dependencies

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -5,244 +5,242 @@ description: Learn how to use Permix with Next.js App Router
 
 ## Overview
 
-Permix provides a dedicated integration for the Next.js **App Router** through `permix/next`. It exposes a `createPermix` factory that returns a **per-request** Permix instance backed by React's [`cache()`](https://react.dev/reference/react/cache), so you can `setup()` the rules once and `check()` them anywhere on the server — layouts, pages, route handlers, and server actions — without threading the instance through props.
+`permix/next` is a request-safe helper for the Next.js **App Router**. You pass a rules resolver into `createPermix`. React's [`cache()`](https://react.dev/reference/react/cache) memoizes **one Promise** of a fully initialized core instance per request, so concurrent Server Components share the same setup instead of racing layout mutation.
 
-The client side reuses the existing React integration (`permix/react`): the server `dehydrate()`s its state and the client hydrates it into its own singleton via `PermixProvider` + `PermixHydrate`.
+The facade exposes **dual access** to that Promise:
+
+- Async `getPermix` / `check` / `getRules` / `dehydrate` for async Server Components
+- `usePermix()` for non-async Server Components — it unwraps the same Promise with React [`use()`](https://react.dev/reference/react/use). `check()` stays synchronous at the call site; React may suspend only while rules resolve
+
+Sync vs async is an **API** choice, not the PPR boundary. A permission UI can prerender after either path when its policy inputs are static or cached. User, session, or cookie-dependent outcomes must stay behind Suspense and must not enter a shared build-time shell.
+
+The client still uses `permix/react`. Hydrate only the permission-dependent islands — do not block the static App Shell on dehydrated state.
 
 <Callout>
-  Before getting started with the Next.js integration, make sure you've
-  completed the initial setup steps in the [Quick Start](/docs/quick-start)
-  guide. Familiarity with the [Hydration guide](/docs/guide/hydration) helps
-  too.
+  Complete the [Quick Start](/docs/quick-start) and read the [Hydration
+  guide](/docs/guide/hydration) before this page.
 </Callout>
 
 <Callout type="warn">
-  This integration is designed for the **App Router**. It relies on `react`'s
-  request-scoped `cache()`, which is available in server components, route
-  handlers, and server actions within a single request.
+  Requires **Next.js 15+**. Route Handlers and Server Actions do **not** share
+  the RSC `cache()` identity. Create and `setup()` an explicit core
+  `createPermix()` instance inside each invocation.
 </Callout>
 
 <Steps>
 
 <Step>
 
-## Define your permissions
-
-Create a Permix instance once in a shared module so it can be imported anywhere on the server:
+## Define the resolver
 
 ```ts title="lib/permix.ts"
 import { createPermix } from 'permix/next'
-
-interface Post {
-  id: string
-  authorId: string
-}
-
-export const permix = createPermix<{
-  post: [
-    { name: 'create'; type: Post },
-    { name: 'read'; type: Post },
-    { name: 'update'; type: Post },
-    { name: 'delete'; type: Post },
-  ]
-}>()
-```
-
-The returned helper does **not** hold any permission state at module scope — every request gets its own isolated instance.
-
-</Step>
-
-<Step>
-
-## Setup per request
-
-Call `setup()` early in the request lifecycle. A common place is the root layout (or any server component that runs before the ones doing `check`s). Resolve any async data (session, headers, cookies, DB lookups) first, then pass plain rules to `setup`:
-
-```tsx title="app/layout.tsx"
-import { permix } from '@/lib/permix'
 import { getSession } from '@/lib/auth'
 
-export default async function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  const session = await getSession()
-
-  permix.setup({
-    post: {
-      create: !!session,
-      read: true,
-      update: (post) => post?.authorId === session?.userId,
-      delete: session?.role === 'admin',
-    },
-  })
-
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  )
-}
-```
-
-<Callout>
-  Because `setup()` is scoped to the current request, calling it again from a
-  nested server component or route handler in the **same** request simply
-  replaces the rules for that request. Other requests are unaffected.
-</Callout>
-
-</Step>
-
-<Step>
-
-## Check on the server
-
-Anywhere a server component, route handler, or server action runs in that request, you can use `check()`:
-
-```tsx title="app/posts/[id]/page.tsx"
-import { notFound } from 'next/navigation'
-import { permix } from '@/lib/permix'
-import { getPost } from '@/lib/posts'
-
-export default async function PostPage({
-  params,
-}: {
-  params: Promise<{ id: string }>
-}) {
-  const { id } = await params
-  const post = await getPost(id)
-
-  if (!permix.check('post.read', post)) {
-    notFound()
-  }
-
-  return <article>{/* ... */}</article>
-}
-```
-
-```ts title="app/api/posts/route.ts"
-import { permix } from '@/lib/permix'
-
-export async function POST(req: Request) {
-  if (!permix.check('post.create')) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
-
-  // create the post...
-  return Response.json({ ok: true })
-}
-```
-
-You can also reach the underlying core instance through `permix.get()` if you need methods like `isReady()` or `getRules()`.
-
-</Step>
-
-<Step>
-
-## Send permissions to the client
-
-Use `dehydrate()` to serialize the request's permissions and hand them to a client provider. The server cannot send the Permix instance itself across the boundary — only the JSON state.
-
-```tsx title="app/providers.tsx"
-'use client'
-
-import { createPermix } from 'permix'
-import { PermixHydrate, PermixProvider } from 'permix/react'
-import type { DehydratedState } from 'permix'
-
-// One singleton per browser tab. The same type definition as on the server.
-const permix = createPermix<{
+export const permix = createPermix<{
   post: [
     { name: 'create'; type: { id: string; authorId: string } },
     { name: 'read'; type: { id: string; authorId: string } },
     { name: 'update'; type: { id: string; authorId: string } },
     { name: 'delete'; type: { id: string; authorId: string } },
   ]
-}>()
-
-export function Providers({
-  state,
-  children,
-}: {
-  state: DehydratedState<any>
-  children: React.ReactNode
-}) {
-  return (
-    <PermixProvider permix={permix}>
-      <PermixHydrate state={state}>{children}</PermixHydrate>
-    </PermixProvider>
-  )
-}
-
-export { permix }
-```
-
-Then wire it up in your root layout right after `setup()`:
-
-```tsx title="app/layout.tsx"
-import { permix } from '@/lib/permix'
-import { getSession } from '@/lib/auth'
-import { Providers } from './providers'
-
-export default async function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+}>(async () => {
   const session = await getSession()
-
-  permix.setup({/* ...rules derived from session... */})
-
-  return (
-    <html lang="en">
-      <body>
-        <Providers state={permix.dehydrate()}>{children}</Providers>
-      </body>
-    </html>
-  )
-}
+  return {
+    post: {
+      create: !!session,
+      read: true,
+      update: (post) => post?.authorId === session?.userId,
+      delete: session?.role === 'admin',
+    },
+  }
+})
 ```
 
-<Callout type="warn">
-  `hydrate()` restores the boolean state but does not flip `isReady` on its own
-  — function-based rules are lost during serialization. If you need `isReady` on
-  the client (e.g. to gate UI on `usePermix(...).isReady`), call
-  `permix.setup(...)` on the client too with the same shape (using booleans and
-  any function rules you want active client-side). See the [Hydration
-  guide](/docs/guide/hydration) for details.
-</Callout>
+The helper holds no permission state at module scope. The first caller in a request starts initialization; every other caller awaits the same Promise.
+
+Keep layouts and pages **synchronous**. Move async permission and data work into feature-owned Server Components, and put shaped skeletons behind **page-owned** Suspense so static chrome remains in the App Shell.
 
 </Step>
 
 <Step>
 
-## Use on the client
+## Async Server Components
 
-From any client component, import the singleton from `app/providers.tsx` and the hooks/components from `permix/react`:
+```tsx title="app/posts/[id]/page.tsx"
+import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
+import { permix } from '@/lib/permix'
+import { getPost } from '@/lib/posts'
 
-```tsx title="app/posts/[id]/edit-button.tsx"
-'use client'
-
-import { usePermix } from 'permix/react'
-import { permix } from '@/app/providers'
-
-export function EditButton({
-  post,
+export default function PostPage({
+  params,
 }: {
-  post: { id: string; authorId: string }
+  params: Promise<{ id: string }>
 }) {
-  const { check } = usePermix(permix)
+  return (
+    <main>
+      <h1>Post</h1>
+      <Suspense fallback={<PostSkeleton />}>
+        {params.then(({ id }) => (
+          <PostArticle id={id} />
+        ))}
+      </Suspense>
+    </main>
+  )
+}
 
-  if (!check('post.update', post)) {
-    return null
+async function PostArticle({ id }: { id: string }) {
+  const post = await getPost(id)
+  if (!post || !(await permix.check('post.read', post))) {
+    notFound()
   }
-
-  return <button>Edit post</button>
+  return <article>{post.id}</article>
 }
 ```
 
-If you prefer the component API, create checkers with `createComponents` from `permix/react` and use them in your client components — see the [React integration](/docs/integrations/react#components) for details.
+`await permix.getPermix()` returns the initialized core instance when you need `isReady()` or multiple synchronous `check()` calls after the await.
+
+</Step>
+
+<Step>
+
+## Non-async Server Components
+
+```tsx title="app/features/sync-read-badge.tsx"
+import { permix } from '@/lib/permix'
+
+export function SyncReadBadge() {
+  const instance = permix.usePermix()
+  return <span>{instance.check('post.read') ? 'allowed' : 'denied'}</span>
+}
+```
+
+Place this behind Suspense. `usePermix()` from `permix/next` is for Server Components. Client components keep using `usePermix` from `permix/react`.
+
+</Step>
+
+<Step>
+
+## Prerender-safe vs request-specific rules
+
+| Outcome | When | Where it lives |
+| --- | --- | --- |
+| Globally cacheable check | Policy inputs are static or `"use cache"` | Shared App Shell |
+| Root-param-keyed check | URL is known (`next/root-params` in **your** resolver); optional `prefetch={true}` | Per-link prefetch |
+| Warm `"use cache: private"` payload | Same session already cached/prefetched | Authorized content can commit immediately |
+| Cold or deliberately fresh session check | Cookie/session/user data, uncached | Dynamic hole behind Suspense |
+
+Permix does not import generated root-param getters. For tenant or locale policies, read `next/root-params` in the **app-owned** resolver (the same pattern as next-intl). Cache serializable policy inputs with `"use cache"`, then build any function rules outside that cache boundary.
+
+Keep ordinary tenant/resource slugs as page values passed through `params.then(...)`. Do not promote a nested slug to a root param solely to avoid prop passing.
+
+</Step>
+
+<Step>
+
+## Permission-first private payloads
+
+Check permission **before** loading feature data. Return serializable data or `null` when denied. An uncached caller performs `notFound()` / `redirect()` — denial control flow stays outside the cached payload. Cache tags remain app-owned; Permix cannot infer a feature's data or membership lifecycle.
+
+```tsx title="app/features/private-edit.tsx"
+import { createPermix } from 'permix'
+import { getSession } from '@/lib/auth'
+import { rulesForSession, type PermissionsDefinition } from '@/lib/permissions'
+import { getPost } from '@/lib/posts'
+
+async function readPostUpdatePayload(postId: string) {
+  'use cache: private'
+  const session = await getSession()
+  const permix = createPermix<PermissionsDefinition>()
+  permix.setup(rulesForSession(session))
+  const post = await getPost(postId)
+  if (!post || !permix.check('post.update', post)) {
+    return null
+  }
+  return { id: post.id, authorId: post.authorId }
+}
+
+export async function PrivateEditIsland({ postId }: { postId: string }) {
+  const payload = await readPostUpdatePayload(postId)
+  if (!payload) {
+    return null
+  }
+  return <EditButton post={payload} />
+}
+```
+
+A client `check()` after hydrate is a **UI hint**, not enforcement. Authoritative decisions stay on the server (this payload, Route Handlers, Server Actions).
+
+</Step>
+
+<Step>
+
+## Hydrate permission-dependent UI only
+
+Create the client bindings with `createPermix` from `permix/react` — same factory name as the server adapter, different import path:
+
+```ts title="lib/client-permix.ts"
+import { createPermix } from 'permix/react'
+import type { PermissionsDefinition } from './permissions'
+
+export const {
+  permix: clientPermix,
+  PermixProvider,
+  PermixHydrate,
+  usePermix,
+  Check,
+} = createPermix<PermissionsDefinition>()
+```
+
+```tsx title="app/providers.tsx"
+'use client'
+
+import type { DehydratedState } from 'permix'
+import { PermixHydrate, PermixProvider } from '@/lib/client-permix'
+import type { PermissionsDefinition } from '@/lib/permissions'
+
+export function Providers({
+  state,
+  children,
+}: {
+  state: DehydratedState<PermissionsDefinition>
+  children: React.ReactNode
+}) {
+  return (
+    <PermixProvider>
+      <PermixHydrate state={state}>{children}</PermixHydrate>
+    </PermixProvider>
+  )
+}
+```
+
+Await `permix.dehydrate()` in the feature that owns the island, not in the root layout. `hydrate()` restores booleans and does not set `isReady`. Call `clientPermix.setup(...)` on the client for function rules — see [Hydration](/docs/guide/hydration).
+
+</Step>
+
+<Step>
+
+## Route Handlers and Server Actions
+
+```ts title="app/api/posts/route.ts"
+import { createPermix } from 'permix'
+import { getSession } from '@/lib/auth'
+import { rulesForSession, type PermissionsDefinition } from '@/lib/permissions'
+
+export async function POST() {
+  const permix = createPermix<PermissionsDefinition>()
+  permix.setup(rulesForSession(await getSession()))
+
+  if (!permix.check('post.create')) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return Response.json({ ok: true })
+}
+```
+
+Share `rulesForSession` (or templates) with the RSC resolver so the policy stays in one place.
 
 </Step>
 
@@ -250,32 +248,15 @@ If you prefer the component API, create checkers with `createComponents` from `p
 
 ## Templates
 
-`createPermix` exposes the same `template()` helper as the core API for reusing rule sets:
+`template()` does not wait on initialization:
 
 ```ts title="lib/permix.ts"
-import { createPermix } from 'permix/next'
-
-export const permix = createPermix<{
-  post: ['create', 'read', 'update', 'delete']
-}>()
-
 export const adminTemplate = permix.template({
   post: { create: true, read: true, update: true, delete: true },
 })
-
-export const guestTemplate = permix.template({
-  post: { create: false, read: true, update: false, delete: false },
-})
 ```
 
-```tsx title="app/layout.tsx"
-import { permix, adminTemplate, guestTemplate } from '@/lib/permix'
-import { getSession } from '@/lib/auth'
-
-const session = await getSession()
-
-permix.setup(session?.role === 'admin' ? adminTemplate() : guestTemplate())
-```
+You can also use `createTemplate` from `permix` in a shared module imported by the resolver, handlers, and the client.
 
 </Step>
 
@@ -283,47 +264,29 @@ permix.setup(session?.role === 'admin' ? adminTemplate() : guestTemplate())
 
 ## Example
 
-You can find a runnable example of the Next.js integration [here](https://github.com/letstri/permix/tree/main/examples/next).
+Runnable App Router example with Cache Components and Partial Prefetching: [examples/next](https://github.com/letstri/permix/tree/main/examples/next).
 
 </Step>
 
 </Steps>
 
-## How per-request isolation works
-
-`createPermix` from `permix/next` wraps a single core instance per request using React's `cache()`. Inside one Next.js request:
-
-- The first call to `setup`/`check`/`get`/`dehydrate` creates (or reuses) **one** instance.
-- All subsequent calls in the same request — across server components, route handlers, and server actions — share that instance.
-
-Across concurrent requests, each request gets its **own** instance. State never leaks between users.
-
-<Callout type="warn">
-  Do **not** store the result of `permix.get()` (or any rule data) in
-  module-level variables. That would defeat per-request isolation. Always go
-  through `permix.check()` / `permix.get()` so the request-scoped cache is
-  consulted.
-</Callout>
-
 ## API
 
-### `createPermix<D>()`
+### `createPermix<D>(resolveRules)`
 
-Returns an object with the following methods:
+`resolveRules` is `() => Rules<D> | Promise<Rules<D>>`.
 
 | Method | Description |
 | --- | --- |
-| `setup(rules)` | Set the per-request permission rules. Resolve any async data (session, etc.) before calling. |
-| `check(...args)` | Check a permission against the current request's rules. Same signature as the core `check`. |
-| `get()` | Return the underlying [`Permix<D>`](/docs/guide/instance) instance for the current request. |
-| `getRules()` | Return the current rules object for the request-scoped instance, or `null`. |
-| `dehydrate()` | Serialize the current request's rules to JSON (for `<PermixHydrate>` on the client). |
-| `template(rules)` | Create a reusable rule set. Same as the core [`template`](/docs/guide/template). |
+| `getPermix()` | Promise of the initialized [`Permix<D>`](/docs/guide/instance) for this request |
+| `usePermix()` | Same instance via React `use()` (Server Components) |
+| `check(...args)` | Async check against the initialized instance |
+| `getRules()` | Async current rules, or `null` |
+| `dehydrate()` | Async JSON snapshot for `<PermixHydrate>` |
+| `template(rules)` | Reusable rule set — same as core [`template`](/docs/guide/template) |
+
+There is no `setup`, `hook`, or `hookOnce` on the Next facade. Initialization is the resolver. Subscribe to core hooks on the instance from `getPermix()` / `usePermix()` if you need them.
 
 ## TanStack Start and other frameworks
 
-The client layer (`permix/react`) is framework-agnostic. If you're using TanStack Start, Remix, or a custom React SSR setup, you can still use `permix/react` on the client. For the server side, either:
-
-- Use the dedicated [`permix/tanstack-start`](/docs/integrations/tanstack-start) integration, which follows the same shape as `permix/next`, or
-- Create a core Permix instance per request manually (see [Hydration guide](/docs/guide/hydration)), or
-- Use an existing server integration like [`permix/node`](/docs/integrations/node), [`permix/express`](/docs/integrations/express), or [`permix/hono`](/docs/integrations/hono) when applicable.
+The client layer (`permix/react`) is framework-agnostic. For TanStack Start use [`permix/tanstack-start`](/docs/integrations/tanstack-start). For other servers, create a core instance per request or use [`permix/node`](/docs/integrations/node), [`permix/express`](/docs/integrations/express), or [`permix/hono`](/docs/integrations/hono).

--- a/docs/content/docs/integrations/react.mdx
+++ b/docs/content/docs/integrations/react.mdx
@@ -5,7 +5,9 @@ description: Learn how to use Permix with React applications
 
 ## Overview
 
-Permix provides official React integration through the `PermixProvider` component and `usePermix` hook. This allows you to manage permissions reactively in your React app.
+Permix provides official React integration through `createPermix` from `permix/react`. Same factory name as `permix/next` and `permix/express`: it returns a Permix instance plus isolated `PermixProvider`, `usePermix`, `Check`, and `PermixHydrate` bindings.
+
+The adapter supports React 18 and React 19. On React 19.2+ it uses native `useEffectEvent`; React 18 gets a compatible fallback. Peers are `react` / `react-dom` `>=18`.
 
 <Callout>
   Before getting started with React integration, make sure you've completed the
@@ -18,25 +20,42 @@ Permix provides official React integration through the `PermixProvider` componen
 
 ## Setup
 
-First, wrap your application with the `PermixProvider`:
+Call `createPermix` once at module scope:
+
+```ts title="lib/permix.ts"
+import { createPermix } from 'permix/react'
+
+export const { permix, PermixProvider, PermixHydrate, usePermix, Check } =
+  createPermix<{
+    post: ['create', 'read', { name: 'edit'; type: Post }]
+  }>()
+```
+
+Pass an existing core instance when you already created one (for example a client copy used with server hydration):
+
+```ts
+import { createPermix } from 'permix/react'
+import { clientPermix } from './client-core'
+
+export const { PermixProvider, PermixHydrate, usePermix, Check } =
+  createPermix(clientPermix)
+```
+
+Wrap the tree with the bound provider. It does not take a `permix` prop — the factory already closed over the instance:
 
 ```tsx title="App.tsx"
-import { PermixProvider } from 'permix/react'
-import { permix } from './lib/permix'
+import { PermixProvider } from './lib/permix'
 
 function App() {
   return (
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <YourApp />
     </PermixProvider>
   )
 }
 ```
 
-<Callout>
-  Remember to always pass the same Permix instance to both the `PermixProvider`
-  and `usePermix` hook to maintain type safety.
-</Callout>
+Each `createPermix` call gets its own React context, so nested factories (for example a posts policy and a comments policy) stay independent.
 
 </Step>
 
@@ -44,14 +63,22 @@ function App() {
 
 ## Hook
 
-For checking permissions in your components, you can use the `usePermix` hook. And to avoid importing the hook and Permix instance in every component, you can create a custom hook:
+`usePermix()` from the factory does not take an instance argument:
 
-```tsx title="hooks/use-permissions.ts"
-import { usePermix } from 'permix/react'
-import { permix } from '../lib/permix'
+```tsx title="page.tsx"
+import { usePermix } from './lib/permix'
 
-export function usePermissions() {
-  return usePermix(permix)
+export default function Page() {
+  const post = usePost()
+  const { check, isReady } = usePermix()
+
+  if (!isReady) {
+    return <div>Loading permissions...</div>
+  }
+
+  const canEdit = check('post.edit', post)
+
+  return canEdit ? <button>Edit Post</button> : null
 }
 ```
 
@@ -61,19 +88,11 @@ export function usePermissions() {
 
 ## Components
 
-If you prefer using components, you can import the `createComponents` function from `permix/react` and create checking components:
-
-```ts title="lib/permix.ts"
-import { createComponents } from 'permix/react'
-
-// ...
-
-export const { Check } = createComponents(permix)
-```
-
-And then you can use the `Check` component in your components:
+The factory also returns a typed `Check` component:
 
 ```tsx title="page.tsx"
+import { Check } from './lib/permix'
+
 export default function Page() {
   return (
     <Check
@@ -92,62 +111,27 @@ export default function Page() {
 
 <Step>
 
-## Usage
-
-Use the `usePermix` hook and checking components in your components:
-
-```tsx title="page.tsx"
-import { usePermix } from 'permix/react'
-import { permix } from './lib/permix'
-import { Check } from './lib/permix-components'
-
-export default function Page() {
-  const post = usePost()
-  const { check, isReady } = usePermix(permix)
-
-  if (!isReady) {
-    return <div>Loading permissions...</div>
-  }
-
-  const canEdit = check('post.edit', post)
-
-  return (
-    <div>
-      {canEdit ? (
-        <button>Edit Post</button>
-      ) : (
-        <p>You don't have permission to edit this post</p>
-      )}
-      <Check path="post.create">
-        Can I create a post inside the Check component?
-      </Check>
-    </div>
-  )
-}
-```
-
-</Step>
-
-<Step>
-
 ## Hydration
 
-For SSR applications, use `PermixHydrate` to restore dehydrated server state on the client. `hydrate()` does not mark the instance ready and cannot restore function-based rules — call `setup()` on the client with the full rule set (usually in the same place you restore the session):
+For SSR, use the bound `PermixHydrate` to restore dehydrated server state on the client. `hydrate()` does not mark the instance ready and cannot restore function-based rules — call `setup()` on the client with the full rule set (usually in the same place you restore the session):
 
 ```tsx title="App.tsx"
 import { useEffect } from 'react'
 import type { DehydratedState } from 'permix'
-import { PermixHydrate, PermixProvider } from 'permix/react'
-import { permix } from './lib/permix'
+import { permix, PermixHydrate, PermixProvider } from './lib/permix'
 import { getClientRules } from './lib/permissions'
 
-function App({ dehydratedState }: { dehydratedState: DehydratedState<any> }) {
+function App({
+  dehydratedState,
+}: {
+  dehydratedState: DehydratedState<{ post: ['create', 'read'] }>
+}) {
   useEffect(() => {
     permix.setup(getClientRules())
   }, [])
 
   return (
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <PermixHydrate state={dehydratedState}>
         <YourApp />
       </PermixHydrate>
@@ -156,7 +140,41 @@ function App({ dehydratedState }: { dehydratedState: DehydratedState<any> }) {
 }
 ```
 
-See the [Hydration guide](/docs/guide/hydration) and framework-specific pages for [Next.js](/docs/integrations/next) and [TanStack Start](/docs/integrations/tanstack-start).
+See the [Hydration guide](/docs/guide/hydration) and framework-specific pages for [Next.js](/docs/integrations/next) and [TanStack Start](/docs/integrations/tanstack-start). `PermixHydrate` uses a dehydrated snapshot on the first render and synchronizes the instance after commit, so boolean checks work before client `setup()`. `isReady` stays `false` until you call `setup()` on the client.
+
+</Step>
+
+<Step>
+
+## Compatible alternative
+
+The previous exports still work: `PermixProvider` with a `permix` prop, `usePermix(permix)`, and `createComponents(permix)`. Always pass the **same** instance to the provider and the hook.
+
+```tsx title="App.tsx"
+import { PermixProvider, usePermix } from 'permix/react'
+import { permix } from './lib/permix'
+
+function App() {
+  return (
+    <PermixProvider permix={permix}>
+      <YourApp />
+    </PermixProvider>
+  )
+}
+
+export function usePermissions() {
+  return usePermix(permix)
+}
+```
+
+```ts title="lib/permix-components.ts"
+import { createComponents } from 'permix/react'
+import { permix } from './lib/permix'
+
+export const { Check } = createComponents(permix)
+```
+
+In development, `usePermix(permix)` throws if the instance does not match the provider.
 
 </Step>
 

--- a/docs/content/docs/integrations/tanstack-start.mdx
+++ b/docs/content/docs/integrations/tanstack-start.mdx
@@ -409,7 +409,7 @@ export function EditButton({
 }
 ```
 
-If you prefer the component API, create checkers with `createComponents` from `permix/react` — see the [React integration](/docs/integrations/react#components) for details.
+If you prefer the component API, use `Check` from `createPermix` in `permix/react` — see the [React integration](/docs/integrations/react).
 
 </Step>
 

--- a/docs/content/docs/migration-v3-to-v4.mdx
+++ b/docs/content/docs/migration-v3-to-v4.mdx
@@ -336,15 +336,15 @@ Map each Better Auth role to a rules object yourself — the same booleans you p
 
 These are additive — migrate the core API first, then adopt what you need:
 
-| Import                  | Use case                                    |
-| ----------------------- | ------------------------------------------- |
-| `permix/next`           | Next.js App Router, request-scoped instance |
-| `permix/tanstack-start` | TanStack Start middleware and SSR           |
-| `permix/server`         | Framework-agnostic fetch middleware         |
-| `permix/svelte`         | Svelte 5 runes                              |
-| `permix/drizzle`        | Rules from Drizzle v1 schema                |
-| `permix/drizzle/legacy` | Drizzle v0 (`>=0.30 <1`)                    |
-| `permix/effect`         | Effect `Layer` / `Context`                  |
+| Import                  | Use case                                       |
+| ----------------------- | ---------------------------------------------- |
+| `permix/next`           | Next.js App Router, resolver + dual RSC access |
+| `permix/tanstack-start` | TanStack Start middleware and SSR              |
+| `permix/server`         | Framework-agnostic fetch middleware            |
+| `permix/svelte`         | Svelte 5 runes                                 |
+| `permix/drizzle`        | Rules from Drizzle v1 schema                   |
+| `permix/drizzle/legacy` | Drizzle v0 (`>=0.30 <1`)                       |
+| `permix/effect`         | Effect `Layer` / `Context`                     |
 
 See the [examples directory](https://github.com/letstri/permix/tree/main/examples) (`next`, `tanstack-start`, `svelte`, `rebac`, and updated `react`, `vue`, …).
 

--- a/docs/content/docs/migration-v3-to-v4.mdx
+++ b/docs/content/docs/migration-v3-to-v4.mdx
@@ -16,7 +16,7 @@ This guide summarizes the breaking changes and how to update your app. For the f
 permix@^4
 ```
 
-v4 is developed with **TypeScript 6**. Your app does not need to match the monorepo's exact TypeScript or pnpm versions, but upgrade TypeScript if you hit inference issues.
+v4 is developed with **TypeScript 7** and supports **TypeScript 5.9–7**. Your app does not need to match the monorepo's exact TypeScript or pnpm versions, but upgrade TypeScript if you hit inference issues.
 
 ## Quick reference
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,8 +9,6 @@
     "check-types": "fumadocs-mdx && tsc --noEmit",
     "dev": "vite dev",
     "postinstall": "fumadocs-mdx",
-    "prebuild": "cd ../permix && pnpm run build",
-    "predeploy": "cd ../permix && pnpm run build",
     "preview": "vite preview",
     "start": "node .output/server/index.mjs"
   },
@@ -26,10 +24,10 @@
     "fumadocs-ui": "^16.9.3",
     "mermaid": "^11.15.0",
     "permix": "workspace:*",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "tailwind-merge": "^3.6.0",
-    "vite": "^8.0.16"
+    "vite": "catalog:"
   },
   "devDependencies": {
     "@orpc/server": "^1.14.4",
@@ -37,10 +35,10 @@
     "@trpc/server": "^11.17.0",
     "@types/express": "^5.0.6",
     "@types/mdx": "^2.0.13",
-    "@types/node": "^24.10.0",
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
     "drizzle-orm": "^1.0.0-rc.3",
     "elysia": "^1.4.28",
     "express": "^5",
@@ -48,6 +46,6 @@
     "hono": "^4.12.23",
     "nitro": "^3.0.260522-beta",
     "tailwindcss": "^4.3.0",
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   }
 }

--- a/examples/enum-based/package.json
+++ b/examples/enum-based/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.6"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/examples/express-trpc-react/package.json
+++ b/examples/express-trpc-react/package.json
@@ -14,19 +14,20 @@
     "cors": "^2.8.6",
     "express": "^5.1.0",
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/pg": "^8.20.0",
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "tsx": "^4.22.4",
-    "vite": "^8.0.16",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
     "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/examples/express-trpc-react/tsconfig.json
+++ b/examples/express-trpc-react/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "moduleDetection": "force",
     "useDefineForClassFields": true,
-    "ignoreDeprecations": "6.0",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "paths": {

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "tsx": "^4.22.4"
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/feature-flags/package.json
+++ b/examples/feature-flags/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.6"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/examples/next/app/actions.ts
+++ b/examples/next/app/actions.ts
@@ -2,8 +2,12 @@
 
 import { revalidatePath } from 'next/cache'
 import { cookies } from 'next/headers'
+import { createPermix } from 'permix'
 
 import type { DemoRole } from '@/lib/auth'
+import { getSession } from '@/lib/auth'
+import type { PermissionsDefinition } from '@/lib/permissions'
+import { rulesForSession } from '@/lib/permissions'
 
 export async function switchRole(formData: FormData) {
   const role = formData.get('role')
@@ -20,4 +24,15 @@ export async function switchRole(formData: FormData) {
   const cookieStore = await cookies()
   cookieStore.set('demo-role', role satisfies DemoRole, { path: '/' })
   revalidatePath('/', 'layout')
+}
+
+export async function createPost() {
+  const permix = createPermix<PermissionsDefinition>()
+  permix.setup(rulesForSession(await getSession()))
+
+  if (!permix.check('post.create')) {
+    return { ok: false as const, error: 'Forbidden' }
+  }
+
+  return { ok: true as const, message: 'Post created (demo)' }
 }

--- a/examples/next/app/api/posts/route.ts
+++ b/examples/next/app/api/posts/route.ts
@@ -1,6 +1,13 @@
-import { permix } from '@/lib/permix'
+import { createPermix } from 'permix'
+
+import { getSession } from '@/lib/auth'
+import type { PermissionsDefinition } from '@/lib/permissions'
+import { rulesForSession } from '@/lib/permissions'
 
 export async function POST() {
+  const permix = createPermix<PermissionsDefinition>()
+  permix.setup(rulesForSession(await getSession()))
+
   if (!permix.check('post.create')) {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }

--- a/examples/next/app/features/post-list.tsx
+++ b/examples/next/app/features/post-list.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+
+import { permix } from '@/lib/permix'
+import type { Post } from '@/lib/permix'
+import { getPosts } from '@/lib/posts'
+
+import { CreatePostForm } from '../components/create-post-form'
+import { PermissionBadge } from '../components/permission-badge'
+import { PrivateEditIsland, PrivateEditIslandSkeleton } from './private-edit'
+
+export async function PostList() {
+  const [posts, canCreate] = await Promise.all([
+    getPosts(),
+    permix.check('post.create'),
+  ])
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-medium">Posts</h2>
+      {posts.map((post) => (
+        <article
+          key={post.id}
+          className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
+        >
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <h3 className="text-base font-medium">Post {post.id}</h3>
+              <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                authorId: {post.authorId}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <PostUpdateBadge post={post} />
+                <PostDeleteBadge post={post} />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                href={`/posts/${post.id}`}
+                prefetch
+                className="rounded-lg border border-zinc-300 px-3 py-1.5 text-sm font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+              >
+                Open page
+              </Link>
+              <Suspense fallback={<PrivateEditIslandSkeleton />}>
+                <PrivateEditIsland postId={post.id} />
+              </Suspense>
+            </div>
+          </div>
+        </article>
+      ))}
+      <CreatePostForm canCreate={canCreate} />
+    </section>
+  )
+}
+
+async function PostUpdateBadge({ post }: { post: Post }) {
+  const allowed = await permix.check('post.update', post)
+  return <PermissionBadge label="server: post.update" allowed={allowed} />
+}
+
+async function PostDeleteBadge({ post }: { post: Post }) {
+  const allowed = await permix.check('post.delete', post)
+  return <PermissionBadge label="server: post.delete" allowed={allowed} />
+}
+
+export function PostListSkeleton() {
+  return (
+    <section className="space-y-4">
+      <div className="h-7 w-24 animate-pulse rounded bg-zinc-200 dark:bg-zinc-800" />
+      <div className="h-40 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900" />
+      <div className="h-40 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900" />
+    </section>
+  )
+}

--- a/examples/next/app/features/private-edit.tsx
+++ b/examples/next/app/features/private-edit.tsx
@@ -1,0 +1,43 @@
+import { createPermix } from 'permix'
+
+import { getSession } from '@/lib/auth'
+import type { PermissionsDefinition } from '@/lib/permissions'
+import { rulesForSession } from '@/lib/permissions'
+import { permix } from '@/lib/permix'
+import { getPost } from '@/lib/posts'
+
+import { EditButton } from '../posts/[id]/edit-button'
+import { Providers } from '../providers'
+
+async function readPostUpdatePayload(postId: string) {
+  'use cache: private'
+  const session = await getSession()
+  const instance = createPermix<PermissionsDefinition>()
+  instance.setup(rulesForSession(session))
+  const post = await getPost(postId)
+  if (!post || !instance.check('post.update', post)) {
+    return null
+  }
+  return { id: post.id, authorId: post.authorId }
+}
+
+export async function PrivateEditIsland({ postId }: { postId: string }) {
+  const payload = await readPostUpdatePayload(postId)
+  if (!payload) {
+    return null
+  }
+
+  const [state, session] = await Promise.all([permix.dehydrate(), getSession()])
+
+  return (
+    <Providers state={state} session={session}>
+      <EditButton post={payload} />
+    </Providers>
+  )
+}
+
+export function PrivateEditIslandSkeleton() {
+  return (
+    <div className="h-9 w-24 animate-pulse rounded-lg bg-zinc-200 dark:bg-zinc-800" />
+  )
+}

--- a/examples/next/app/features/public-read-badge.tsx
+++ b/examples/next/app/features/public-read-badge.tsx
@@ -1,0 +1,12 @@
+import { publicPermix } from '@/lib/permix'
+
+import { PermissionBadge } from '../components/permission-badge'
+
+export async function PublicReadBadge() {
+  'use cache'
+  const allowed = await publicPermix.check('post.read')
+
+  return (
+    <PermissionBadge label="post.read (public, cacheable)" allowed={allowed} />
+  )
+}

--- a/examples/next/app/features/server-checks.tsx
+++ b/examples/next/app/features/server-checks.tsx
@@ -1,0 +1,28 @@
+import { permix } from '@/lib/permix'
+import { getPosts } from '@/lib/posts'
+
+import { PermissionBadge } from '../components/permission-badge'
+import { SyncReadBadge } from './sync-read-badge'
+
+export async function ServerChecks() {
+  const posts = await getPosts()
+  const canCreate = await permix.check('post.create')
+  const canRead = await permix.check('post.read', posts[0])
+
+  return (
+    <section className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+      <h2 className="text-lg font-medium">Server checks in this request</h2>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <PermissionBadge label="await check post.create" allowed={canCreate} />
+        <PermissionBadge label="await check post.read" allowed={canRead} />
+        <SyncReadBadge />
+      </div>
+    </section>
+  )
+}
+
+export function ServerChecksSkeleton() {
+  return (
+    <section className="h-28 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900" />
+  )
+}

--- a/examples/next/app/features/session-panel.tsx
+++ b/examples/next/app/features/session-panel.tsx
@@ -1,0 +1,27 @@
+import { getDemoRole, getSession } from '@/lib/auth'
+
+import { RoleSwitcher } from '../components/role-switcher'
+
+export async function SessionPanel() {
+  const [session, role] = await Promise.all([getSession(), getDemoRole()])
+
+  return (
+    <section className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-medium">Current session</h2>
+          <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+            {session ? session.label : 'Signed out (guest)'}
+          </p>
+        </div>
+        <RoleSwitcher currentRole={role} />
+      </div>
+    </section>
+  )
+}
+
+export function SessionPanelSkeleton() {
+  return (
+    <section className="h-28 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900" />
+  )
+}

--- a/examples/next/app/features/sync-read-badge.tsx
+++ b/examples/next/app/features/sync-read-badge.tsx
@@ -1,0 +1,14 @@
+import { permix } from '@/lib/permix'
+
+import { PermissionBadge } from '../components/permission-badge'
+
+export function SyncReadBadge() {
+  const instance = permix.usePermix()
+
+  return (
+    <PermissionBadge
+      label="usePermix() post.read"
+      allowed={instance.check('post.read')}
+    />
+  )
+}

--- a/examples/next/app/layout.tsx
+++ b/examples/next/app/layout.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
-import { getSession } from '@/lib/auth'
-import { adminTemplate, guestTemplate, permix } from '@/lib/permix'
-
-import { Providers } from './providers'
-
 import './globals.css'
 
 const geistSans = Geist({
@@ -23,39 +18,18 @@ export const metadata: Metadata = {
   description: 'Live example of the permix/next integration',
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const session = await getSession()
-
-  if (session) {
-    permix.setup(
-      session.role === 'admin'
-        ? adminTemplate()
-        : {
-            post: {
-              create: true,
-              read: true,
-              update: (post) => post?.authorId === session.userId,
-              delete: false,
-            },
-          }
-    )
-  } else {
-    permix.setup(guestTemplate())
-  }
-
   return (
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">
-        <Providers state={permix.dehydrate()} session={session}>
-          {children}
-        </Providers>
+        {children}
       </body>
     </html>
   )

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,29 +1,19 @@
-import Link from 'next/link'
+import { Suspense } from 'react'
 
-import { getDemoRole, getSession } from '@/lib/auth'
-import { permix } from '@/lib/permix'
-import { getPosts } from '@/lib/posts'
+import { PostList, PostListSkeleton } from './features/post-list'
+import { PublicReadBadge } from './features/public-read-badge'
+import { ServerChecks, ServerChecksSkeleton } from './features/server-checks'
+import { SessionPanel, SessionPanelSkeleton } from './features/session-panel'
 
-import { CreatePostForm } from './components/create-post-form'
-import { PermissionBadge } from './components/permission-badge'
-import { RoleSwitcher } from './components/role-switcher'
-import { EditButton } from './posts/[id]/edit-button'
-
-export default async function Home() {
-  const [session, role, posts] = await Promise.all([
-    getSession(),
-    getDemoRole(),
-    getPosts(),
-  ])
-
+export default function Home() {
   return (
     <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-8 px-6 py-10">
-      <header className="space-y-3">
+      <header className="space-y-3" data-testid="app-shell">
         <p className="text-sm font-medium tracking-wide text-zinc-500 uppercase">
           Permix + Next.js App Router
         </p>
         <h1 className="text-3xl font-semibold tracking-tight">
-          Per-request permissions demo
+          Request-safe permissions demo
         </h1>
         <p className="max-w-2xl text-zinc-600 dark:text-zinc-400">
           This example mirrors the{' '}
@@ -33,76 +23,26 @@ export default async function Home() {
           >
             Next.js integration guide
           </a>
-          . Rules are set once in the root layout, checked on the server in
-          pages and route handlers, then dehydrated for client components.
+          . A rules resolver initializes one cached instance per request. Static
+          chrome stays in the App Shell; session-aware checks stream behind
+          Suspense.
         </p>
+        <Suspense fallback={null}>
+          <PublicReadBadge />
+        </Suspense>
       </header>
 
-      <section className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 className="text-lg font-medium">Current session</h2>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-              {session ? session.label : 'Signed out (guest)'}
-            </p>
-          </div>
-          <RoleSwitcher currentRole={role} />
-        </div>
-      </section>
+      <Suspense fallback={<SessionPanelSkeleton />}>
+        <SessionPanel />
+      </Suspense>
 
-      <section className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
-        <h2 className="text-lg font-medium">Server checks in this request</h2>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <PermissionBadge
-            label="post.create"
-            allowed={permix.check('post.create')}
-          />
-          <PermissionBadge
-            label="post.read (any post)"
-            allowed={permix.check('post.read', posts[0])}
-          />
-        </div>
-      </section>
+      <Suspense fallback={<ServerChecksSkeleton />}>
+        <ServerChecks />
+      </Suspense>
 
-      <section className="space-y-4">
-        <h2 className="text-lg font-medium">Posts</h2>
-        {posts.map((post) => (
-          <article
-            key={post.id}
-            className="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900"
-          >
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="space-y-2">
-                <h3 className="text-base font-medium">Post {post.id}</h3>
-                <p className="text-sm text-zinc-600 dark:text-zinc-400">
-                  authorId: {post.authorId}
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  <PermissionBadge
-                    label="server: post.update"
-                    allowed={permix.check('post.update', post)}
-                  />
-                  <PermissionBadge
-                    label="server: post.delete"
-                    allowed={permix.check('post.delete', post)}
-                  />
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Link
-                  href={`/posts/${post.id}`}
-                  className="rounded-lg border border-zinc-300 px-3 py-1.5 text-sm font-medium hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
-                >
-                  Open page
-                </Link>
-                <EditButton post={post} />
-              </div>
-            </div>
-          </article>
-        ))}
-      </section>
-
-      <CreatePostForm canCreate={permix.check('post.create')} />
+      <Suspense fallback={<PostListSkeleton />}>
+        <PostList />
+      </Suspense>
     </main>
   )
 }

--- a/examples/next/app/posts/[id]/edit-button.tsx
+++ b/examples/next/app/posts/[id]/edit-button.tsx
@@ -1,12 +1,10 @@
 'use client'
 
-import { usePermix } from 'permix/react'
-
-import { permix } from '@/app/providers'
-import type { Post } from '@/lib/permix'
+import { usePermix } from '@/lib/client-permix'
+import type { Post } from '@/lib/permissions'
 
 export function EditButton({ post }: { post: Post }) {
-  const { check } = usePermix(permix)
+  const { check } = usePermix()
 
   if (!check('post.update', post)) {
     return null

--- a/examples/next/app/posts/[id]/page.tsx
+++ b/examples/next/app/posts/[id]/page.tsx
@@ -1,23 +1,20 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
 
 import { permix } from '@/lib/permix'
 import { getPost } from '@/lib/posts'
 
-import { EditButton } from './edit-button'
+import {
+  PrivateEditIsland,
+  PrivateEditIslandSkeleton,
+} from '../../features/private-edit'
 
-export default async function PostPage({
+export default function PostPage({
   params,
 }: {
   params: Promise<{ id: string }>
 }) {
-  const { id } = await params
-  const post = await getPost(id)
-
-  if (!post || !permix.check('post.read', post)) {
-    notFound()
-  }
-
   return (
     <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-6 px-6 py-10">
       <Link
@@ -26,25 +23,47 @@ export default async function PostPage({
       >
         ← Back to posts
       </Link>
-
-      <article className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Post {post.id}
-        </h1>
-        <p className="mt-2 text-zinc-600 dark:text-zinc-400">
-          authorId: {post.authorId}
-        </p>
-        <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
-          This page calls{' '}
-          <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs dark:bg-zinc-800">
-            permix.check(&apos;post.read&apos;, post)
-          </code>{' '}
-          on the server before rendering.
-        </p>
-        <div className="mt-6">
-          <EditButton post={post} />
-        </div>
-      </article>
+      <Suspense fallback={<PostArticleSkeleton />}>
+        {params.then(({ id }) => (
+          <PostArticle id={id} />
+        ))}
+      </Suspense>
     </main>
+  )
+}
+
+async function PostArticle({ id }: { id: string }) {
+  const post = await getPost(id)
+
+  if (!post || !(await permix.check('post.read', post))) {
+    notFound()
+  }
+
+  return (
+    <article className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+      <h1 className="text-2xl font-semibold tracking-tight">Post {post.id}</h1>
+      <p className="mt-2 text-zinc-600 dark:text-zinc-400">
+        authorId: {post.authorId}
+      </p>
+      <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
+        This page calls{' '}
+        <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-xs dark:bg-zinc-800">
+          await permix.check(&apos;post.read&apos;, post)
+        </code>{' '}
+        on the server before rendering. The edit control is a privately cached
+        payload — a UI hint, not enforcement.
+      </p>
+      <div className="mt-6">
+        <Suspense fallback={<PrivateEditIslandSkeleton />}>
+          <PrivateEditIsland postId={post.id} />
+        </Suspense>
+      </div>
+    </article>
+  )
+}
+
+function PostArticleSkeleton() {
+  return (
+    <div className="h-64 animate-pulse rounded-xl border border-zinc-200 bg-zinc-100 dark:border-zinc-800 dark:bg-zinc-900" />
   )
 }

--- a/examples/next/app/providers.tsx
+++ b/examples/next/app/providers.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import type { DehydratedState } from 'permix'
-import { createPermix } from 'permix'
-import { PermixHydrate, PermixProvider } from 'permix/react'
 import { useLayoutEffect } from 'react'
 
 import type { Session } from '@/lib/auth'
-import type { PermissionsDefinition } from '@/lib/permix'
-
-const permix = createPermix<PermissionsDefinition>()
+import {
+  clientPermix,
+  PermixHydrate,
+  PermixProvider,
+} from '@/lib/client-permix'
+import { rulesForSession } from '@/lib/permissions'
+import type { PermissionsDefinition } from '@/lib/permissions'
 
 function ClientRulesSetup({
   session,
@@ -18,14 +20,7 @@ function ClientRulesSetup({
   children: React.ReactNode
 }) {
   useLayoutEffect(() => {
-    permix.setup({
-      post: {
-        create: !!session,
-        read: true,
-        update: (post) => post?.authorId === session?.userId,
-        delete: session?.role === 'admin',
-      },
-    })
+    clientPermix.setup(rulesForSession(session))
   }, [session])
 
   return children
@@ -41,12 +36,10 @@ export function Providers({
   children: React.ReactNode
 }) {
   return (
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <PermixHydrate state={state}>
         <ClientRulesSetup session={session}>{children}</ClientRulesSetup>
       </PermixHydrate>
     </PermixProvider>
   )
 }
-
-export { permix }

--- a/examples/next/lib/client-permix.ts
+++ b/examples/next/lib/client-permix.ts
@@ -1,0 +1,11 @@
+import { createPermix } from 'permix/react'
+
+import type { PermissionsDefinition } from './permissions'
+
+export const {
+  permix: clientPermix,
+  PermixProvider,
+  PermixHydrate,
+  usePermix,
+  Check,
+} = createPermix<PermissionsDefinition>()

--- a/examples/next/lib/permissions.ts
+++ b/examples/next/lib/permissions.ts
@@ -1,0 +1,51 @@
+import { createTemplate } from 'permix'
+import type { Rules, ValidateDefinition } from 'permix'
+
+import type { Session } from './auth'
+
+export interface Post {
+  id: string
+  authorId: string
+}
+
+export type PermissionsDefinition = ValidateDefinition<{
+  post: [
+    { name: 'create'; type: Post },
+    { name: 'read'; type: Post },
+    { name: 'update'; type: Post },
+    { name: 'delete'; type: Post },
+  ]
+}>
+
+export const adminTemplate = createTemplate<PermissionsDefinition>({
+  post: { create: true, read: true, update: true, delete: true },
+})
+
+export const guestTemplate = createTemplate<PermissionsDefinition>({
+  post: { create: false, read: true, update: false, delete: false },
+})
+
+export const publicReadTemplate = createTemplate<PermissionsDefinition>({
+  post: { create: false, read: true, update: false, delete: false },
+})
+
+export function rulesForSession(
+  session: Session | null
+): Rules<PermissionsDefinition> {
+  if (!session) {
+    return guestTemplate()
+  }
+
+  if (session.role === 'admin') {
+    return adminTemplate()
+  }
+
+  return {
+    post: {
+      create: true,
+      read: true,
+      update: (post) => post?.authorId === session.userId,
+      delete: false,
+    },
+  }
+}

--- a/examples/next/lib/permix.ts
+++ b/examples/next/lib/permix.ts
@@ -1,26 +1,16 @@
-import type { ValidateDefinition } from 'permix'
 import { createPermix } from 'permix/next'
 
-export interface Post {
-  id: string
-  authorId: string
-}
+import { getSession } from './auth'
+import type { PermissionsDefinition } from './permissions'
+import { publicReadTemplate, rulesForSession } from './permissions'
 
-export type PermissionsDefinition = ValidateDefinition<{
-  post: [
-    { name: 'create'; type: Post },
-    { name: 'read'; type: Post },
-    { name: 'update'; type: Post },
-    { name: 'delete'; type: Post },
-  ]
-}>
+export const permix = createPermix<PermissionsDefinition>(async () =>
+  rulesForSession(await getSession())
+)
 
-export const permix = createPermix<PermissionsDefinition>()
+export const publicPermix = createPermix<PermissionsDefinition>(() =>
+  publicReadTemplate()
+)
 
-export const adminTemplate = permix.template({
-  post: { create: true, read: true, update: true, delete: true },
-})
-
-export const guestTemplate = permix.template({
-  post: { create: false, read: true, update: false, delete: false },
-})
+export { adminTemplate, guestTemplate, rulesForSession } from './permissions'
+export type { PermissionsDefinition, Post } from './permissions'

--- a/examples/next/next.config.ts
+++ b/examples/next/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   transpilePackages: ['permix'],
+  cacheComponents: true,
+  partialPrefetching: true,
+  experimental:
+    process.env.EXPOSE_TESTING_API === '1'
+      ? {
+          exposeTestingApiInProductionBuild: true,
+        }
+      : undefined,
 }
 
 export default nextConfig

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,15 +10,15 @@
   "dependencies": {
     "next": "16.2.6",
     "permix": "workspace:*",
-    "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/node": "^25.9.1",
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
     "tailwindcss": "^4.3.0",
-    "typescript": "^6.0.3"
+    "typescript": "catalog:"
   }
 }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "16.2.6",
+    "next": "16.3.3",
     "permix": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.6"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/examples/react/src/hooks/permissions.ts
+++ b/examples/react/src/hooks/permissions.ts
@@ -1,7 +1,5 @@
-import { usePermix } from 'permix/react'
-
-import { permix } from '../lib/permix'
+import { usePermix } from '../lib/permix'
 
 export function usePermissions() {
-  return usePermix(permix)
+  return usePermix()
 }

--- a/examples/react/src/lib/permix.ts
+++ b/examples/react/src/lib/permix.ts
@@ -1,10 +1,9 @@
-import { createPermix } from 'permix'
-import { createComponents } from 'permix/react'
+import { createPermix } from 'permix/react'
 
 import type { Post } from '../hooks/posts'
 import type { User } from '../hooks/user'
 
-export const permix = createPermix<{
+export const { permix, PermixProvider, usePermix, Check } = createPermix<{
   post: ['read', { name: 'edit'; type: Post }]
 }>()
 
@@ -16,5 +15,3 @@ export function setupPermix(user: User) {
     },
   })
 }
-
-export const { Check } = createComponents(permix)

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -1,15 +1,14 @@
-import { PermixProvider } from 'permix/react'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
 import App from './App.tsx'
-import { permix } from './lib/permix.ts'
+import { PermixProvider } from './lib/permix.ts'
 
 import './index.css'
 
 createRoot(document.querySelector('#root')!).render(
   <StrictMode>
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <App />
     </PermixProvider>
   </StrictMode>

--- a/examples/rebac/package.json
+++ b/examples/rebac/package.json
@@ -10,8 +10,8 @@
     "permix": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^25.9.1",
-    "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/examples/role-based/package.json
+++ b/examples/role-based/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.6"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -14,8 +14,8 @@
     "solid-js": "^1.9.13"
   },
   "devDependencies": {
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16",
+    "typescript": "catalog:",
+    "vite": "catalog:",
     "vite-plugin-solid": "^2.11.12"
   }
 }

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -20,10 +20,10 @@
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/kit": "^2.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/node": "^25.9.1",
+    "@types/node": "catalog:",
     "svelte": "^5.55.2",
     "svelte-check": "^4.5.0",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -22,8 +22,8 @@
     "@tanstack/router-plugin": "^1.132.0",
     "lucide-react": "^0.545.0",
     "permix": "workspace:*",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
@@ -32,13 +32,13 @@
     "@tanstack/router-cli": "^1.132.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@types/node": "^22.10.2",
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
     "jsdom": "^28.1.0",
-    "typescript": "^6.0.2",
-    "vite": "^8.0.0",
-    "vitest": "^4.1.5"
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "vue-tsc -b && vite build",
-    "check-types": "vue-tsc --noEmit",
+    "build": "node --import ../../permix/scripts/register-typescript6.mjs ./node_modules/vue-tsc/bin/vue-tsc.js -b && vite build",
+    "check-types": "node --import ../../permix/scripts/register-typescript6.mjs ./node_modules/vue-tsc/bin/vue-tsc.js --noEmit",
     "dev": "vite",
     "preview": "vite preview"
   },
@@ -16,8 +16,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/tsconfig": "^0.9.1",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16",
+    "typescript": "catalog:",
+    "vite": "catalog:",
     "vue-tsc": "^3.3.3"
   }
 }

--- a/ignores.ts
+++ b/ignores.ts
@@ -9,6 +9,7 @@ export const ignorePatterns = [
   '**/out/**',
   '**/node_modules/**',
   '**/_artifacts/**',
+  '**/.agents/**',
   '**/next-env.d.ts',
   '**/*.gen.ts',
   '**/*.generated.ts',

--- a/ignores.ts
+++ b/ignores.ts
@@ -15,4 +15,8 @@ export const ignorePatterns = [
   '**/*.generated.ts',
   'examples/svelte/src/lib/index.ts',
   'pnpm-lock.yaml',
+  'permix/test/next/.scratch/**',
+  'permix/test/next/playwright-report/**',
+  'permix/test/next/test-results/**',
+  'permix/test/next/**',
 ]

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -119,6 +119,12 @@ export default defineConfig({
   overrides: [
     ...vitestOverrides,
     {
+      files: ['permix/test-d/**'],
+      rules: {
+        'typescript/consistent-type-definitions': 'off',
+      },
+    },
+    {
       files: nonReactGlobs,
       rules: {
         'react-hooks/rules-of-hooks': 'off',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -125,6 +125,14 @@ export default defineConfig({
       },
     },
     {
+      files: ['permix/src/react/**'],
+      rules: {
+        'typescript/no-explicit-any': 'error',
+        'typescript/consistent-type-imports': 'error',
+        'react/exhaustive-effect-dependencies': 'error',
+      },
+    },
+    {
       files: nonReactGlobs,
       rules: {
         'react-hooks/rules-of-hooks': 'off',

--- a/package.json
+++ b/package.json
@@ -2,27 +2,31 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "cd permix && pnpm run build",
-    "check-types": "turbo check-types",
+    "build": "turbo run build --filter=permix",
+    "check-types": "turbo run check-types",
     "format": "oxfmt --config ./oxfmt.config.ts --ignore-path .gitignore .",
     "format:check": "oxfmt --config ./oxfmt.config.ts --ignore-path .gitignore --check .",
     "lint": "oxlint --type-aware --config ./oxlint.config.ts --ignore-path .gitignore --deny-warnings .",
     "lint:fix": "oxlint --type-aware --config ./oxlint.config.ts --ignore-path .gitignore --fix --deny-warnings .",
     "prepare": "husky",
     "publish": "cd permix && pnpm publish",
-    "test": "cd permix && pnpm run test",
+    "test": "turbo run test --filter=permix",
     "update": "taze -r -I major"
   },
   "devDependencies": {
     "husky": "^9.1.7",
     "npm-run-all2": "^9.0.1",
-    "oxfmt": "^0.64.0",
-    "oxlint": "^1.79.0",
-    "oxlint-tsgolint": "^7.0.2001",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
     "taze": "^19.14.1",
-    "turbo": "^2.9.16",
-    "typescript": "^6.0.3",
-    "ultracite": "^7.10.6"
+    "turbo": "catalog:",
+    "typescript": "catalog:",
+    "ultracite": "catalog:"
   },
-  "packageManager": "pnpm@11.5.0"
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=11.0.0"
+  },
+  "packageManager": "pnpm@11.24.0"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky",
     "publish": "cd permix && pnpm publish",
     "test": "turbo run test --filter=permix",
+    "test:next": "pnpm --filter permix build && pnpm --filter @permix/next-integration test",
     "update": "taze -r -I major"
   },
   "devDependencies": {

--- a/permix/package.json
+++ b/permix/package.json
@@ -119,9 +119,13 @@
     }
   },
   "scripts": {
-    "build": "tsdown && pnpm run build:svelte",
-    "build:svelte": "svelte-package -i src/svelte -o dist/svelte && node ./scripts/build-svelte.ts",
-    "check-types": "tsc --build && svelte-check --tsconfig ./tsconfig.svelte.json",
+    "build": "node --import ./scripts/register-typescript6.mjs ./node_modules/tsdown/dist/run.mjs && pnpm run build:svelte",
+    "build:svelte": "node --import ./scripts/register-typescript6.mjs ./node_modules/@sveltejs/package/src/cli.js -i src/svelte -o dist/svelte && node ./scripts/build-svelte.ts",
+    "check-types": "tsc --build && node --import ./scripts/register-typescript6.mjs ./node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.svelte.json",
+    "type-check:compat:5.9": "pnpm run build && node ./node_modules/typescript59/bin/tsc --build && node ./node_modules/typescript59/bin/tsc -p tsconfig.compat.json && node ./scripts/smoke-exports.ts",
+    "type-check:compat:6": "pnpm run build && node ./node_modules/typescript6/bin/tsc6 --build && node ./node_modules/typescript6/bin/tsc6 -p tsconfig.compat.json --stableTypeOrdering && node ./scripts/smoke-exports.ts",
+    "type-check:compat:7": "pnpm run build && tsc --build && tsc -p tsconfig.compat.json && node ./scripts/smoke-exports.ts",
+    "type-check:compat": "pnpm run type-check:compat:5.9 && pnpm run type-check:compat:6 && pnpm run type-check:compat:7",
     "prepublishOnly": "run-s check-types test build scripts:copy-readme skills:validate",
     "scripts:copy-readme": "node ./scripts/copy-readme.ts",
     "skills:stale": "intent stale skills",
@@ -138,23 +142,26 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/svelte": "^5.3.1",
     "@types/express": "^5.0.6",
-    "@types/node": "^25.9.1",
-    "@types/react": "^19.2.15",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "@types/supertest": "^7.2.0",
-    "@vitejs/plugin-react": "^6.0.2",
+    "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "^4.1.8",
     "@vue/test-utils": "^2.4.10",
     "drizzle-orm": "1.0.0-rc.3",
     "effect": "^3.21.2",
     "happy-dom": "^20.9.0",
-    "react-dom": "^19.2.6",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "supertest": "^7.2.2",
     "svelte": "^5.56.0",
     "svelte-check": "^4.5.0",
     "tsdown": "^0.22.1",
-    "typescript": "^6.0.3",
+    "typescript": "catalog:",
+    "typescript59": "catalog:typescript-classic",
+    "typescript6": "catalog:typescript-classic",
     "vite-plugin-solid": "^2.11.12",
-    "vitest": "^4.1.8",
+    "vitest": "catalog:",
     "vue": "^3.5.17",
     "zod": "^4.4.3"
   },
@@ -174,6 +181,7 @@
     "react-dom": ">=18",
     "solid-js": ">=1",
     "svelte": ">=5",
+    "typescript": ">=5.9 <8",
     "vue": ">=3"
   },
   "peerDependenciesMeta": {
@@ -224,12 +232,15 @@
     },
     "vue": {
       "optional": true
+    },
+    "typescript": {
+      "optional": true
     }
   },
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.24.0",
   "intent": {
     "repo": "letstri/permix",
     "docs": "../docs/content/docs"

--- a/permix/package.json
+++ b/permix/package.json
@@ -176,7 +176,7 @@
     "fastify": ">=5",
     "fastify-plugin": ">=5",
     "hono": ">=4",
-    "next": ">=14",
+    "next": ">=15",
     "react": ">=18",
     "react-dom": ">=18",
     "solid-js": ">=1",

--- a/permix/scripts/register-typescript6.mjs
+++ b/permix/scripts/register-typescript6.mjs
@@ -1,0 +1,26 @@
+import { createRequire, registerHooks } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'typescript/lib/tsc') {
+      // vue-tsc patches the TS 5.9 tsc shim; TS 6/7 lib/tsc is not patchable.
+      return {
+        shortCircuit: true,
+        url: pathToFileURL(require.resolve('typescript59/lib/tsc.js')).href,
+      }
+    }
+
+    if (specifier === 'typescript' || specifier.startsWith('typescript/')) {
+      const mapped = specifier.replace(/^typescript(?=\/|$)/, 'typescript6')
+      return {
+        shortCircuit: true,
+        url: pathToFileURL(require.resolve(mapped)).href,
+      }
+    }
+
+    return nextResolve(specifier, context)
+  },
+})

--- a/permix/scripts/smoke-exports.ts
+++ b/permix/scripts/smoke-exports.ts
@@ -1,0 +1,24 @@
+const entrypoints = [
+  ['.', await import('permix'), ['createPermix']],
+  ['./trpc', await import('permix/trpc'), ['createPermix']],
+  ['./orpc', await import('permix/orpc'), ['createPermix']],
+  ['./express', await import('permix/express'), ['createPermix']],
+  ['./hono', await import('permix/hono'), ['createPermix']],
+  ['./node', await import('permix/node'), ['createPermix']],
+  ['./server', await import('permix/server'), ['createPermix']],
+  ['./elysia', await import('permix/elysia'), ['createPermix']],
+  ['./fastify', await import('permix/fastify'), ['createPermix']],
+  ['./drizzle', await import('permix/drizzle'), ['createPermix']],
+  ['./drizzle/legacy', await import('permix/drizzle/legacy'), ['createPermix']],
+  ['./effect', await import('permix/effect'), ['createPermix']],
+] as const
+
+for (const [subpath, module, expectedExports] of entrypoints) {
+  for (const exportName of expectedExports) {
+    if (!(exportName in module)) {
+      throw new Error(
+        `Missing ${exportName} export from permix${subpath === '.' ? '' : subpath}`
+      )
+    }
+  }
+}

--- a/permix/skills/permix/SKILL.md
+++ b/permix/skills/permix/SKILL.md
@@ -37,7 +37,7 @@ Assumes a `permix` instance already exists (see **permix-getting-started**). Loa
 | Task | Reference |
 | --- | --- |
 | `permix.check()` paths, callbacks, `~all`/`~any`, ReBAC/ABAC with entity data, `isReady` | [references/check.md](references/check.md) |
-| React, Vue, Solid, or Svelte UI — `PermixProvider`, `usePermix`, `createComponents`, SSR `dehydrate`/`hydrate` for Next.js / TanStack Start | [references/frontend.md](references/frontend.md) |
+| React, Vue, Solid, or Svelte UI — `createPermix` from `permix/react` (or `PermixProvider` / `usePermix` / `createComponents`), SSR `dehydrate`/`hydrate` for Next.js / TanStack Start | [references/frontend.md](references/frontend.md) |
 | Protecting Express, Hono, Fastify, tRPC, oRPC, Node, or Elysia routes — `setupMiddleware`, `checkMiddleware` | [references/server.md](references/server.md) |
 
 ## Rules that apply everywhere

--- a/permix/skills/permix/references/frontend.md
+++ b/permix/skills/permix/references/frontend.md
@@ -6,44 +6,30 @@ Docs: https://permix.letstri.dev/docs/integrations/react
 
 ## React
 
-### Provider
+### Factory (recommended)
+
+Call `createPermix` from `permix/react` once at module scope — same name as `permix/next` and `permix/express`. It returns a Permix instance plus bound Provider, `usePermix`, `Check`, and `PermixHydrate` with an isolated context. Nested factories do not share state.
+
+```ts
+import { createPermix } from 'permix/react'
+
+export const { permix, PermixProvider, PermixHydrate, usePermix, Check } =
+  createPermix<{ post: ['create', 'read'] }>()
+```
 
 ```tsx
-import { PermixProvider } from 'permix/react'
-import { permix } from './lib/permix'
+import { PermixProvider, usePermix, Check } from './lib/permix'
 
 export function App() {
   return (
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <Routes />
     </PermixProvider>
   )
 }
-```
 
-### Setup after auth
-
-```ts
-// e.g. after session loads
-await loadUser()
-permix.setup(roleRulesFor(user))
-```
-
-### Hook (wrap once)
-
-```ts
-// hooks/use-permissions.ts
-import { usePermix } from 'permix/react'
-import { permix } from '../lib/permix'
-
-export function usePermissions() {
-  return usePermix(permix)
-}
-```
-
-```tsx
 function EditButton({ post }) {
-  const { check, isReady } = usePermissions()
+  const { check, isReady } = usePermix()
 
   if (!isReady) return null
 
@@ -53,26 +39,47 @@ function EditButton({ post }) {
 }
 ```
 
-Pass the **same** `permix` instance to `PermixProvider` and `usePermix`.
-
-### Declarative `Check` component
-
-```ts
-import { createComponents } from 'permix/react'
-
-export const { Check } = createComponents(permix)
-```
-
 ```tsx
 <Check path="post.create" otherwise={<span>Denied</span>}>
   <CreateForm />
 </Check>
 ```
 
+Supports React 18 and React 19. Native `useEffectEvent` is used on React 19.2+; React 18 uses a compatible fallback.
+
+### Setup after auth
+
+```ts
+// e.g. after session loads
+await loadUser()
+permix.setup(roleRulesFor(user))
+```
+
+### Compatible alternative
+
+`PermixProvider` with a `permix` prop, `usePermix(permix)`, and `createComponents(permix)` still work. Pass the **same** `permix` instance to the provider and the hook — in development a mismatch throws.
+
 ```tsx
-<Check path="post.update" data={post} reverse>
-  Hidden when allowed; shown when denied
-</Check>
+import { PermixProvider, usePermix } from 'permix/react'
+import { permix } from './lib/permix'
+
+export function App() {
+  return (
+    <PermixProvider permix={permix}>
+      <Routes />
+    </PermixProvider>
+  )
+}
+
+export function usePermissions() {
+  return usePermix(permix)
+}
+```
+
+```ts
+import { createComponents } from 'permix/react'
+
+export const { Check } = createComponents(permix)
 ```
 
 ### SSR
@@ -169,15 +176,16 @@ Skipping client `setup` after hydrate leaves dynamic/ReBAC checks wrong.
 ### React
 
 ```tsx
-import { DehydratedState, PermixHydrate, PermixProvider } from 'permix/react'
+import type { DehydratedState } from 'permix'
+import { permix, PermixHydrate, PermixProvider } from './lib/permix'
 
 function App({
   dehydratedState,
 }: {
-  dehydratedState: DehydratedState<typeof schema>
+  dehydratedState: DehydratedState<{ post: ['create', 'read'] }>
 }) {
   return (
-    <PermixProvider permix={permix}>
+    <PermixProvider>
       <PermixHydrate state={dehydratedState}>
         <YourApp />
       </PermixHydrate>
@@ -186,11 +194,13 @@ function App({
 }
 ```
 
-Run client `permix.setup(...)` where you restore the session (e.g. after `PermixHydrate` mounts or in the same auth effect).
+Run client `permix.setup(...)` where you restore the session (e.g. after `PermixHydrate` mounts or in the same auth effect). `PermixHydrate` supplies dehydrated booleans on the first render without mutating the instance during render; the instance hydrates after commit. `isReady` stays `false` until client `setup()`.
 
 ### Next.js / TanStack Start
 
 Use framework helpers from `permix/next` or `permix/tanstack-start` when available — they wire dehydrate/hydrate into the framework data flow.
+
+**Next.js App Router (`permix/next`)** — `createPermix(resolveRules)` caches one initialized instance per request. Async Server Components `await getPermix()` / `await check()`. Non-async Server Components call `usePermix()` (React `use()`); `check()` is sync at the call site. Keep layouts/pages synchronous; put async permission/data work in feature components behind page-owned Suspense. Cookie/session checks stay out of the shared App Shell. `"use cache"` / `next/root-params` belong in the **app** resolver, not inside Permix. `"use cache: private"` payloads should check permission before loading data and return `null` when denied; `notFound()`/`redirect()` stay uncached. Client `check` is a UI hint. Route Handlers and Server Actions must `createPermix()` + `setup()` a core instance per invocation — they do not share RSC `cache()`.
 
 In TanStack Start, `permix.get(context)` only works in server functions and server routes. To check inside `beforeLoad`/`loader`, put a core instance on the **router context** in `getRouter()` (`context: { permix }`), type it with `createRootRouteWithContext`, hydrate it in the root route's `beforeLoad`, then call `context.permix.check(...)` in any child route. Passing only the context type without the runtime value leaves `context.permix` undefined.
 

--- a/permix/src/core/check.ts
+++ b/permix/src/core/check.ts
@@ -51,10 +51,14 @@ function walk(rules: Rules<any>, inputArgs: unknown[]): boolean {
     const last = parts.at(-1)
 
     if (isSpecialSymbol(last)) {
-      let subtree: Rule = rules
+      let subtree: Rule | undefined = rules
       for (let i = 0; i < parts.length - 1; i++) {
+        const segment = parts[i]
+        if (segment === undefined) {
+          break
+        }
         if (subtree && typeof subtree === 'object') {
-          subtree = (subtree as Record<string, Rule>)[parts[i]]
+          subtree = (subtree as Record<string, Rule>)[segment]
         }
       }
 
@@ -72,7 +76,10 @@ function walk(rules: Rules<any>, inputArgs: unknown[]): boolean {
           return void out.push(callRuleWithoutData(rule))
         }
         for (const key in rule) {
-          visit(rule[key])
+          const child = rule[key]
+          if (child !== undefined) {
+            visit(child)
+          }
         }
       }
       visit(subtree)
@@ -84,10 +91,14 @@ function walk(rules: Rules<any>, inputArgs: unknown[]): boolean {
     }
   }
 
-  let rule: Rule = rules
+  let rule: Rule | undefined = rules
   let i = 0
   for (; i < args.length && typeof rule === 'object'; i++) {
-    rule = rule[String(args[i])]
+    const arg = args[i]
+    if (typeof arg !== 'string') {
+      break
+    }
+    rule = (rule as Record<string, Rule>)[arg]
   }
 
   if (typeof rule === 'boolean') {
@@ -142,5 +153,10 @@ export function createCheckContext<D extends Definition>(
     return { path: first }
   }
 
-  return { path: first, data: params[1] }
+  const data = params[1]
+  if (data === undefined) {
+    return { path: first }
+  }
+
+  return { path: first, data }
 }

--- a/permix/src/core/errors.ts
+++ b/permix/src/core/errors.ts
@@ -28,7 +28,9 @@ export class PermixNotFoundError extends PermixError {
   constructor(key?: string | symbol) {
     super('Instance not found. Please setup the permix instance first.')
     this.name = 'PermixNotFoundError'
-    this.key = key
+    if (key !== undefined) {
+      this.key = key
+    }
   }
 }
 

--- a/permix/src/core/permix.test.ts
+++ b/permix/src/core/permix.test.ts
@@ -139,16 +139,18 @@ describe(createPermix, () => {
     expect(permix.check('post.create')).toBe(true)
   })
 
-  it('should work with enum-based permissions', () => {
-    enum PostAction {
-      Create = 'create',
-      Read = 'read',
-      Update = 'update',
-      Delete = 'delete',
-    }
+  it('should work with enum-like permissions', () => {
+    const PostAction = {
+      Create: 'create',
+      Read: 'read',
+      Update: 'update',
+      Delete: 'delete',
+    } as const
+
+    type PostActionName = (typeof PostAction)[keyof typeof PostAction]
 
     const permix = createPermix<{
-      post: [PostAction]
+      post: [PostActionName]
     }>()
 
     permix.setup({

--- a/permix/src/hono/permix.ts
+++ b/permix/src/hono/permix.ts
@@ -93,7 +93,8 @@ function buildPermix<D extends Definition>(
         return await onForbidden({ c, ...createCheckContext(...args) })
       }
 
-      await next()
+      // oxlint-disable-next-line typescript/no-confusing-void-expression -- Hono's next() is Promise<void>
+      return await next()
     })
 
   function getRules(c: Context): Rules<D> | null {

--- a/permix/src/next/hydration.test.tsx
+++ b/permix/src/next/hydration.test.tsx
@@ -1,47 +1,38 @@
 import { render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createPermix as createCorePermix } from '../core'
 import { PermixHydrate, PermixProvider, usePermix } from '../react'
 import { createPermix as createNextPermix } from './permix'
+import { resetRequestCache } from './request-cache-mock'
 import '@testing-library/jest-dom/vitest'
 
-// See ./permix.test.ts — outside a Next.js request scope `cache()` does not
-// memoize, so we mock it for the test environment.
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
+  const { createRequestScopedCache } = await import('./request-cache-mock')
   return {
     ...actual,
-    cache: <T extends (...args: any[]) => any>(fn: T): T => {
-      const store = new Map<string, ReturnType<T>>()
-      return ((...args: Parameters<T>) => {
-        const key = JSON.stringify(args)
-        if (!store.has(key)) {
-          store.set(key, fn(...args))
-        }
-        return store.get(key)!
-      }) as T
-    },
+    cache: createRequestScopedCache,
   }
 })
 
 describe('next → react hydration round-trip', () => {
+  afterEach(() => {
+    resetRequestCache()
+  })
+
   it('hydrates dehydrated server state on the client', async () => {
-    // Server: setup + dehydrate using the Next.js per-request helper.
     const permixServer = createNextPermix<{
       post: ['create', 'read']
-    }>()
-
-    permixServer.setup({
+    }>(() => ({
       post: {
         create: true,
         read: false,
       },
-    })
+    }))
 
-    const state = permixServer.dehydrate()
+    const state = await permixServer.dehydrate()
 
-    // Client: separate singleton + hydrate via the react integration.
     const permixClient = createCorePermix<{
       post: ['create', 'read']
     }>()

--- a/permix/src/next/permix.test.ts
+++ b/permix/src/next/permix.test.ts
@@ -1,93 +1,94 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createPermix } from './permix'
+import { resetRequestCache } from './request-cache-mock'
 
-// React's `cache()` only memoizes within a Next.js request scope (backed by
-// AsyncLocalStorage). Outside of one — including in vitest — it returns a
-// fresh value on every call, which would defeat the per-request instance
-// pattern. We replace it here with a simple module-level memoizer so that a
-// single `createPermix()` call behaves as if it were running inside one
-// Next.js request for the duration of the test.
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
+  const { createRequestScopedCache } = await import('./request-cache-mock')
   return {
     ...actual,
-    cache: <T extends (...args: any[]) => any>(fn: T): T => {
-      const store = new Map<string, ReturnType<T>>()
-      return ((...args: Parameters<T>) => {
-        const key = JSON.stringify(args)
-        if (!store.has(key)) {
-          store.set(key, fn(...args))
+    cache: createRequestScopedCache,
+    use: <T>(usable: T | PromiseLike<T>): T => {
+      if (
+        usable !== null &&
+        usable !== undefined &&
+        typeof (usable as PromiseLike<T>).then === 'function'
+      ) {
+        const thenable = usable as PromiseLike<T> & {
+          status?: 'fulfilled' | 'rejected' | 'pending'
+          value?: T
+          reason?: unknown
         }
-        return store.get(key)!
-      }) as T
+        if (thenable.status === 'fulfilled') {
+          return thenable.value as T
+        }
+        if (thenable.status === 'rejected') {
+          throw thenable.reason
+        }
+        throw thenable
+      }
+      return usable as T
     },
   }
 })
 
 describe('next createPermix', () => {
-  it('sets up rules and checks permissions', () => {
+  afterEach(() => {
+    resetRequestCache()
+  })
+
+  it('initializes from a sync resolver and checks permissions', async () => {
     const permix = createPermix<{
       post: ['create', 'read']
-    }>()
-
-    permix.setup({
+    }>(() => ({
       post: {
         create: true,
         read: false,
       },
-    })
+    }))
 
-    expect(permix.check('post.create')).toBe(true)
-    expect(permix.check('post.read')).toBe(false)
+    await expect(permix.check('post.create')).resolves.toBe(true)
+    await expect(permix.check('post.read')).resolves.toBe(false)
   })
 
-  it('works with data resolved before setup', async () => {
+  it('initializes from an async resolver', async () => {
     const permix = createPermix<{
       post: ['create']
-    }>()
-
-    // Mimic the documented pattern: await your own data, then call setup
-    // with plain rules. No async wrapper around setup needed.
-    const user = await Promise.resolve({ role: 'admin' as const })
-
-    permix.setup({
-      post: {
-        create: user.role === 'admin',
-      },
+    }>(async () => {
+      const user = await Promise.resolve({ role: 'admin' as const })
+      return {
+        post: {
+          create: user.role === 'admin',
+        },
+      }
     })
 
-    expect(permix.check('post.create')).toBe(true)
+    await expect(permix.check('post.create')).resolves.toBe(true)
   })
 
-  it('exposes the underlying core instance via get()', () => {
+  it('returns the initialized core instance from getPermix', async () => {
     const permix = createPermix<{
       post: ['create']
-    }>()
+    }>(() => ({ post: { create: true } }))
 
-    permix.setup({ post: { create: true } })
-
-    const core = permix.get()
+    const core = await permix.getPermix()
 
     expect(core.isReady()).toBe(true)
     expect(core.check('post.create')).toBe(true)
   })
 
-  it('reads the current rules with getRules', () => {
+  it('reads the current rules with getRules', async () => {
     const permix = createPermix<{
       post: ['create', 'read']
-    }>()
-
-    expect(permix.getRules()).toBeNull()
-
-    permix.setup({
+    }>(() => ({
       post: {
         create: true,
         read: false,
       },
-    })
+    }))
 
-    expect(permix.getRules()).toStrictEqual({
+    await expect(permix.getRules()).resolves.toStrictEqual({
       post: {
         create: true,
         read: false,
@@ -95,19 +96,17 @@ describe('next createPermix', () => {
     })
   })
 
-  it('dehydrates the request-scoped state', () => {
+  it('dehydrates the request-scoped state', async () => {
     const permix = createPermix<{
       post: ['create', 'read']
-    }>()
-
-    permix.setup({
+    }>(() => ({
       post: {
         create: true,
         read: false,
       },
-    })
+    }))
 
-    expect(permix.dehydrate()).toStrictEqual({
+    await expect(permix.dehydrate()).resolves.toStrictEqual({
       post: {
         create: true,
         read: false,
@@ -115,35 +114,86 @@ describe('next createPermix', () => {
     })
   })
 
-  it('reuses the same instance across calls in the same request scope', () => {
+  it('shares one initialized instance across concurrent callers', async () => {
+    let calls = 0
     const permix = createPermix<{
       post: ['create']
-    }>()
+    }>(async () => {
+      calls++
+      await Promise.resolve()
+      return { post: { create: true } }
+    })
 
-    permix.setup({ post: { create: true } })
+    const [first, second, allowed] = await Promise.all([
+      permix.getPermix(),
+      permix.getPermix(),
+      permix.check('post.create'),
+    ])
 
-    // Two get() calls in the same "request" must return the same instance,
-    // proving that setup() persists across subsequent calls.
-    expect(permix.get()).toBe(permix.get())
-    expect(permix.check('post.create')).toBe(true)
+    expect(calls).toBe(1)
+    expect(first).toBe(second)
+    expect(allowed).toBe(true)
+    expect(first.check('post.create')).toBe(true)
   })
 
-  it('isolates state between independent factories', () => {
-    const permixA = createPermix<{ post: ['create'] }>()
-    const permixB = createPermix<{ post: ['create'] }>()
+  it('isolates state between independent factories', async () => {
+    const permixA = createPermix<{ post: ['create'] }>(() => ({
+      post: { create: true },
+    }))
+    const permixB = createPermix<{ post: ['create'] }>(() => ({
+      post: { create: false },
+    }))
 
-    permixA.setup({ post: { create: true } })
-    permixB.setup({ post: { create: false } })
-
-    expect(permixA.check('post.create')).toBe(true)
-    expect(permixB.check('post.create')).toBe(false)
-    expect(permixA.get()).not.toBe(permixB.get())
+    await expect(permixA.check('post.create')).resolves.toBe(true)
+    await expect(permixB.check('post.create')).resolves.toBe(false)
+    const [coreA, coreB] = await Promise.all([
+      permixA.getPermix(),
+      permixB.getPermix(),
+    ])
+    expect(coreA).not.toBe(coreB)
   })
 
-  it('creates reusable templates', () => {
+  it('isolates state across simulated requests of the same factory', async () => {
+    let requestRole: 'admin' | 'guest' = 'admin'
+    const permix = createPermix<{ post: ['create'] }>(() => ({
+      post: { create: requestRole === 'admin' },
+    }))
+
+    await expect(permix.check('post.create')).resolves.toBe(true)
+    const first = await permix.getPermix()
+
+    resetRequestCache()
+    requestRole = 'guest'
+
+    await expect(permix.check('post.create')).resolves.toBe(false)
+    await expect(permix.getPermix()).resolves.not.toBe(first)
+  })
+
+  it('usePermix unwraps the same initialized instance', async () => {
+    const permix = createPermix<{
+      post: ['create']
+    }>(() => ({ post: { create: true } }))
+
+    const instancePromise = permix.getPermix()
+    const instance = await instancePromise
+    Object.assign(instancePromise, {
+      status: 'fulfilled',
+      value: instance,
+    })
+
+    expect(permix.usePermix()).toBe(instance)
+    expect(instance.check('post.create')).toBe(true)
+  })
+
+  it('creates reusable templates without waiting on initialization', () => {
     const permix = createPermix<{
       post: ['create', 'read']
-    }>()
+    }>(() => ({
+      post: {
+        create: false,
+        read: false,
+      },
+    }))
 
     const adminTemplate = permix.template({
       post: {
@@ -163,7 +213,11 @@ describe('next createPermix', () => {
   it('supports parameterized templates', () => {
     const permix = createPermix<{
       post: [{ name: 'edit'; type: { authorId: string } }]
-    }>()
+    }>(() => ({
+      post: {
+        edit: () => false,
+      },
+    }))
 
     const template = permix.template((userId: string) => ({
       post: {

--- a/permix/src/next/permix.ts
+++ b/permix/src/next/permix.ts
@@ -1,101 +1,107 @@
-import { cache } from 'react'
+import { cache, use } from 'react'
 
 import type { Permix as PermixCore } from '../core'
 import { createPermix as createPermixCore, createTemplate } from '../core'
+import type { CheckArgs } from '../core/check'
 import type { Definition } from '../core/definitions'
-import type { PermixHooks, Rules, RulesPaths } from '../core/permix'
+import type { Rules, RulesPaths } from '../core/permix'
 import type { DehydratedState } from '../core/rules'
 
+export type ResolveRules<D extends Definition> = () =>
+  | Rules<D>
+  | Promise<Rules<D>>
+
 /**
- * Create a per-request Permix instance for Next.js App Router.
+ * Create a per-request Permix helper for the Next.js App Router.
  *
- * Backed by React's `cache()`, so all server components, route handlers, and
- * server actions within the same request share one instance while concurrent
- * requests stay fully isolated.
+ * Pass a sync or async rules resolver. React's `cache()` memoizes one Promise
+ * of a fully initialized core instance per request, so concurrent RSC callers
+ * share the same setup instead of racing layout mutation order.
+ *
+ * Use the async getters from async Server Components, Route Handlers, and
+ * Server Actions. Use `usePermix()` from non-async Server Components — it
+ * unwraps the same Promise with React `use()`, so `check()` stays synchronous
+ * at the call site while React may suspend only while rules resolve.
+ *
+ * Route Handlers and Server Actions do not share the RSC `cache()` identity.
+ * Prefer an explicit core `createPermix()` + `setup()` inside each invocation
+ * when those entry points must authorize independently of the render tree.
  *
  * @example
  * ```ts
  * // lib/permix.ts
  * import { createPermix } from 'permix/next'
+ * import { getSession } from '@/lib/auth'
  *
  * export const permix = createPermix<{
  *   post: ['create', 'read', 'update', 'delete']
- * }>()
- * ```
- *
- * ```tsx
- * // app/layout.tsx (server component)
- * import { permix } from '@/lib/permix'
- * import { getSession } from '@/lib/auth'
- *
- * export default async function RootLayout({ children }) {
+ * }>(async () => {
  *   const session = await getSession()
- *
- *   permix.setup({
+ *   return {
  *     post: {
  *       create: !!session,
  *       read: true,
  *       update: session?.role === 'admin',
  *       delete: session?.role === 'admin',
  *     },
- *   })
+ *   }
+ * })
+ * ```
  *
- *   return <Providers state={permix.dehydrate()}>{children}</Providers>
- * }
+ * ```tsx
+ * // async Server Component
+ * const canCreate = await permix.check('post.create')
+ *
+ * // non-async Server Component
+ * const instance = permix.usePermix()
+ * const canRead = instance.check('post.read')
  * ```
  *
  * @link https://permix.letstri.dev/docs/integrations/next
  */
-export function createPermix<D extends Definition>() {
-  // Per-request isolation: concurrent requests each get their own instance;
-  // multiple callers within one request share the same one.
-  const getPermix = cache((): PermixCore<D> => createPermixCore<D>())
+export function createPermix<D extends Definition>(
+  resolveRules: ResolveRules<D>
+) {
+  const getInitializedPermix = cache(async (): Promise<PermixCore<D>> => {
+    const permix = createPermixCore<D>()
+    permix.setup(await Promise.resolve(resolveRules()))
+    return permix
+  })
 
-  function setup(rules: Rules<D>): void {
-    getPermix().setup(rules)
+  function getPermix(): Promise<PermixCore<D>> {
+    return getInitializedPermix()
   }
 
-  const check: PermixCore<D>['check'] = (...args) => getPermix().check(...args)
-
-  function dehydrate(): DehydratedState<D> {
-    return getPermix().dehydrate()
+  function usePermix(): PermixCore<D> {
+    return use(getInitializedPermix())
   }
 
-  function get(): PermixCore<D> {
-    return getPermix()
+  async function check(...args: CheckArgs<D>): Promise<boolean> {
+    const permix = await getInitializedPermix()
+    return permix.check(...args)
   }
 
-  function getRules(): Rules<D> | null {
-    return getPermix().getRules()
+  async function getRules(): Promise<Rules<D> | null> {
+    const permix = await getInitializedPermix()
+    return permix.getRules()
+  }
+
+  async function dehydrate(): Promise<DehydratedState<D>> {
+    const permix = await getInitializedPermix()
+    return permix.dehydrate()
   }
 
   function template<T = void>(rules: Rules<D> | ((param: T) => Rules<D>)) {
     return createTemplate<D, T>(rules)
   }
 
-  function hook<K extends keyof PermixHooks<D>>(
-    name: K,
-    fn: PermixHooks<D>[K]
-  ) {
-    return getPermix().hook(name, fn)
-  }
-
-  function hookOnce<K extends keyof PermixHooks<D>>(
-    name: K,
-    fn: PermixHooks<D>[K]
-  ) {
-    getPermix().hookOnce(name, fn)
-  }
-
   return {
-    setup,
+    getPermix,
+    usePermix,
     check,
-    dehydrate,
-    get,
     getRules,
+    dehydrate,
     template,
-    hook,
-    hookOnce,
     $inferDefinition: undefined as unknown as D,
     $inferPath: undefined as unknown as RulesPaths<D>,
   }

--- a/permix/src/next/request-cache-mock.ts
+++ b/permix/src/next/request-cache-mock.ts
@@ -1,0 +1,34 @@
+/**
+ * Request-scoped stand-in for React's `cache()` in vitest.
+ *
+ * Real `cache()` memoizes within a Next.js request (AsyncLocalStorage). In
+ * vitest there is no request scope, so the default implementation does not
+ * share work across callers. This helper memoizes like one request, and
+ * {@link resetRequestCache} starts a new generation so tests can simulate
+ * the next request without pretending the cache is process-global forever.
+ */
+let generation = 0
+
+export function resetRequestCache(): void {
+  generation++
+}
+
+export function createRequestScopedCache<T extends (...args: any[]) => any>(
+  fn: T
+): T {
+  const stores = new Map<number, Map<string, ReturnType<T>>>()
+
+  return ((...args: Parameters<T>) => {
+    let store = stores.get(generation)
+    if (!store) {
+      store = new Map()
+      stores.set(generation, store)
+    }
+
+    const key = JSON.stringify(args)
+    if (!store.has(key)) {
+      store.set(key, fn(...args) as ReturnType<T>)
+    }
+    return store.get(key)!
+  }) as T
+}

--- a/permix/src/node/permix.test.ts
+++ b/permix/src/node/permix.test.ts
@@ -325,7 +325,7 @@ describe('checkMiddleware without setupMiddleware', () => {
     await permix.checkMiddleware('post.create')(req, res, next)
 
     expect(next).toHaveBeenCalledOnce()
-    expect(next.mock.calls[0][0]).toBeInstanceOf(PermixNotFoundError)
+    expect(next.mock.calls[0]?.[0]).toBeInstanceOf(PermixNotFoundError)
   })
 })
 

--- a/permix/src/react/components.test.tsx
+++ b/permix/src/react/components.test.tsx
@@ -1,10 +1,13 @@
 import { render, waitFor } from '@testing-library/react'
+import * as React from 'react'
+// @ts-expect-error react-dom/server has no types under tsconfig.react.json `types: []`
+import { renderToString } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom/vitest'
 
 import { createPermix, PermixRuleNotDefinedError } from '../core'
 import { createComponents, PermixHydrate, PermixProvider } from './components'
 import { usePermix } from './hooks'
-import '@testing-library/jest-dom/vitest'
 
 describe('components', () => {
   it('should check hydration', async () => {
@@ -39,6 +42,150 @@ describe('components', () => {
     )
 
     expect(container.firstChild).toHaveTextContent('true')
+  })
+
+  it('uses dehydrated rules on the first render without mutating the instance', () => {
+    const permixServer = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    permixServer.setup({
+      post: {
+        create: true,
+        read: false,
+      },
+    })
+
+    const dehydrated = permixServer.dehydrate()
+    const permixClient = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    function TestComponent() {
+      const { check, isReady } = usePermix(permixClient)
+      return <div>{`${check('post.create')}:${isReady}`}</div>
+    }
+
+    const html = renderToString(
+      <PermixProvider permix={permixClient}>
+        <PermixHydrate state={dehydrated}>
+          <TestComponent />
+        </PermixHydrate>
+      </PermixProvider>
+    )
+
+    expect(html).toContain('true:false')
+    expect(permixClient.getRules()).toBeNull()
+    expect(permixClient.isReady()).toBe(false)
+  })
+
+  it('keeps isReady false after hydration until client setup', async () => {
+    const permixServer = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    permixServer.setup({
+      post: {
+        create: true,
+        read: false,
+      },
+    })
+
+    const dehydrated = permixServer.dehydrate()
+    const permixClient = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    function TestComponent() {
+      const { check, isReady } = usePermix(permixClient)
+      return (
+        <div>
+          <span data-testid="hydrate-create">
+            {check('post.create').toString()}
+          </span>
+          <span data-testid="hydrate-ready">{isReady.toString()}</span>
+        </div>
+      )
+    }
+
+    const { getByTestId } = render(
+      <React.StrictMode>
+        <PermixProvider permix={permixClient}>
+          <PermixHydrate state={dehydrated}>
+            <TestComponent />
+          </PermixHydrate>
+        </PermixProvider>
+      </React.StrictMode>
+    )
+
+    expect(getByTestId('hydrate-create')).toHaveTextContent('true')
+    expect(getByTestId('hydrate-ready')).toHaveTextContent('false')
+
+    permixClient.setup({
+      post: {
+        create: true,
+        read: false,
+      },
+    })
+
+    await waitFor(() => {
+      expect(getByTestId('hydrate-ready')).toHaveTextContent('true')
+    })
+  })
+
+  it('replaces hydrated booleans when setup supplies new rules', async () => {
+    const permixServer = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    permixServer.setup({
+      post: {
+        create: true,
+        read: false,
+      },
+    })
+
+    const dehydrated = permixServer.dehydrate()
+    const permixClient = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    function TestComponent() {
+      const { check } = usePermix(permixClient)
+      return (
+        <div>
+          <span data-testid="replace-create">
+            {check('post.create').toString()}
+          </span>
+          <span data-testid="replace-read">
+            {check('post.read').toString()}
+          </span>
+        </div>
+      )
+    }
+
+    const { getByTestId } = render(
+      <PermixProvider permix={permixClient}>
+        <PermixHydrate state={dehydrated}>
+          <TestComponent />
+        </PermixHydrate>
+      </PermixProvider>
+    )
+
+    expect(getByTestId('replace-create')).toHaveTextContent('true')
+    expect(getByTestId('replace-read')).toHaveTextContent('false')
+
+    permixClient.setup({
+      post: {
+        create: false,
+        read: true,
+      },
+    })
+
+    await waitFor(() => {
+      expect(getByTestId('replace-create')).toHaveTextContent('false')
+      expect(getByTestId('replace-read')).toHaveTextContent('true')
+    })
   })
 
   it('should work with Check component', () => {

--- a/permix/src/react/components.tsx
+++ b/permix/src/react/components.tsx
@@ -6,10 +6,34 @@ import type {
   Definition,
   DehydratedState,
   Permix,
+  Rules,
   RulesPaths,
 } from '../core'
 import type { PermixContext } from './hooks'
 import { Context, usePermix, usePermixContext } from './hooks'
+import { useEffectEvent } from './use-effect-event'
+import { useLayoutEffect } from './use-isomorphic-layout-effect'
+
+function readPermixSnapshot<D extends Definition>(
+  permix: Permix<D>
+): PermixContext<D> {
+  return {
+    permix,
+    isReady: permix.isReady(),
+    rules: permix.getRules(),
+  }
+}
+
+function snapshotsEqual<D extends Definition>(
+  left: PermixContext<D>,
+  right: PermixContext<D>
+): boolean {
+  return (
+    left.permix === right.permix &&
+    left.isReady === right.isReady &&
+    left.rules === right.rules
+  )
+}
 
 /**
  * Provides Permix context to the React component tree.
@@ -19,56 +43,79 @@ import { Context, usePermix, usePermixContext } from './hooks'
 export function PermixProvider<D extends Definition>({
   children,
   permix,
+  context,
 }: {
   children: React.ReactNode
   permix: Permix<D>
+  context?: React.Context<PermixContext<D> | null>
 }) {
-  const [context, setContext] = React.useState<PermixContext<D>>(() => ({
-    permix,
-    isReady: permix.isReady(),
-    rules: permix.getRules(),
-  }))
+  const Ctx = context ?? (Context as React.Context<PermixContext<D> | null>)
+  const snapshotRef = React.useRef<PermixContext<D> | null>(null)
 
-  React.useEffect(() => {
-    const syncRules = () => {
-      queueMicrotask(() => {
-        setContext((c) => ({ ...c, rules: permix.getRules() }))
-      })
-    }
-    const syncReady = () => {
-      queueMicrotask(() => {
-        setContext((c) => ({ ...c, isReady: permix.isReady() }))
-      })
-    }
-    const setup = permix.hook('setup', syncRules)
-    const ready = permix.hook('ready', syncReady)
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      const unsubSetup = permix.hook('setup', onStoreChange)
+      const unsubReady = permix.hook('ready', onStoreChange)
+      onStoreChange()
+      return () => {
+        unsubSetup()
+        unsubReady()
+      }
+    },
+    [permix]
+  )
 
-    return () => {
-      setup()
-      ready()
+  const getSnapshot = React.useCallback(() => {
+    const next = readPermixSnapshot(permix)
+    const prev = snapshotRef.current
+    if (prev && snapshotsEqual(prev, next)) {
+      return prev
     }
+    snapshotRef.current = next
+    return next
   }, [permix])
 
-  return <Context.Provider value={context}>{children}</Context.Provider>
+  const snapshot = React.useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot
+  )
+
+  return <Ctx.Provider value={snapshot}>{children}</Ctx.Provider>
 }
 
-export function PermixHydrate({
+export function PermixHydrate<D extends Definition>({
   children,
   state,
+  context,
 }: {
   children: React.ReactNode
-  state: DehydratedState<any>
+  state: DehydratedState<D>
+  context?: React.Context<PermixContext<D> | null>
 }) {
-  const { permix } = usePermixContext()
+  const Ctx = context ?? (Context as React.Context<PermixContext<D> | null>)
+  const parent = usePermixContext(context)
 
-  // Run before children render so `check()` can use hydrated booleans on the first pass.
-  // PermixProvider defers context updates from the `setup` hook to avoid setState during render.
-  // eslint-disable-next-line react/use-memo, react/void-use-memo
-  React.useMemo(() => {
-    permix.hydrate(state)
-  }, [permix, state])
+  const hydrateEvent = useEffectEvent((nextState: DehydratedState<D>) => {
+    parent.permix.hydrate(nextState)
+  })
 
-  return children
+  useLayoutEffect(() => {
+    hydrateEvent(state)
+  }, [state])
+
+  const overlay = React.useMemo<PermixContext<D>>(
+    () => ({
+      permix: parent.permix,
+      isReady: parent.isReady,
+      rules: state as unknown as Rules<D>,
+    }),
+    [parent.permix, parent.isReady, state]
+  )
+
+  const value = parent.rules === null ? overlay : parent
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }
 
 export interface CheckProps<D extends Definition, P extends RulesPaths<D>> {
@@ -84,7 +131,8 @@ export interface PermixComponents<D extends Definition> {
 }
 
 export function createComponents<D extends Definition>(
-  permix: Pick<Permix<D>, 'getRules' | 'check'>
+  permix: Pick<Permix<D>, 'getRules' | 'check'>,
+  context?: React.Context<PermixContext<D> | null>
 ): PermixComponents<D> {
   function Check<P extends RulesPaths<D>>({
     children,
@@ -93,7 +141,7 @@ export function createComponents<D extends Definition>(
     otherwise = null,
     reverse = false,
   }: CheckProps<D, P>) {
-    const { check } = usePermix(permix)
+    const { check } = usePermix(permix, context)
 
     const hasPermission = check(...([path, data] as unknown as CheckArgs<D>))
     return reverse

--- a/permix/src/react/create-permix.test.tsx
+++ b/permix/src/react/create-permix.test.tsx
@@ -1,0 +1,205 @@
+import { render, waitFor } from '@testing-library/react'
+import * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+
+import { createPermix as createCore } from '../core'
+import { createPermix } from './create-permix'
+import { PermixProvider, usePermix } from './index'
+
+describe('react factory contexts', () => {
+  it('creates a core instance and bound UI when called with a definition', () => {
+    const {
+      permix,
+      PermixProvider: BoundProvider,
+      usePermix: useBoundPermix,
+      Check,
+    } = createPermix<{
+      post: ['read']
+    }>()
+
+    permix.setup({
+      post: {
+        read: true,
+      },
+    })
+
+    function HookLabel() {
+      const { check, isReady } = useBoundPermix()
+      return (
+        <span data-testid="hook">{`${isReady}:${check('post.read')}`}</span>
+      )
+    }
+
+    const { getByTestId, getByText } = render(
+      <BoundProvider>
+        <HookLabel />
+        <Check path="post.read">
+          <span>allowed</span>
+        </Check>
+      </BoundProvider>
+    )
+
+    expect(getByTestId('hook')).toHaveTextContent('true:true')
+    expect(getByText('allowed')).toBeInTheDocument()
+  })
+
+  it('wraps an existing core instance', () => {
+    const permix = createCore<{
+      post: ['read']
+    }>()
+
+    permix.setup({
+      post: {
+        read: true,
+      },
+    })
+
+    const ui = createPermix(permix)
+
+    expect(ui.permix).toBe(permix)
+
+    function HookLabel() {
+      const { check } = ui.usePermix()
+      return <span data-testid="wrap">{check('post.read').toString()}</span>
+    }
+
+    const { getByTestId } = render(
+      <ui.PermixProvider>
+        <HookLabel />
+      </ui.PermixProvider>
+    )
+
+    expect(getByTestId('wrap')).toHaveTextContent('true')
+  })
+
+  it('keeps nested factory contexts independent', () => {
+    const postsUI = createPermix<{
+      post: ['read']
+    }>()
+    const commentsUI = createPermix<{
+      comment: ['read']
+    }>()
+
+    postsUI.permix.setup({
+      post: {
+        read: true,
+      },
+    })
+    commentsUI.permix.setup({
+      comment: {
+        read: false,
+      },
+    })
+
+    function Nested() {
+      const postsState = postsUI.usePermix()
+      const commentsState = commentsUI.usePermix()
+      return (
+        <div>
+          <span data-testid="post">
+            {postsState.check('post.read').toString()}
+          </span>
+          <span data-testid="comment">
+            {commentsState.check('comment.read').toString()}
+          </span>
+          <postsUI.Check path="post.read">
+            <span data-testid="post-check">post-ok</span>
+          </postsUI.Check>
+          <commentsUI.Check path="comment.read">
+            <span data-testid="comment-check">comment-ok</span>
+          </commentsUI.Check>
+        </div>
+      )
+    }
+
+    const { getByTestId, queryByTestId } = render(
+      <postsUI.PermixProvider>
+        <commentsUI.PermixProvider>
+          <Nested />
+        </commentsUI.PermixProvider>
+      </postsUI.PermixProvider>
+    )
+
+    expect(getByTestId('post')).toHaveTextContent('true')
+    expect(getByTestId('comment')).toHaveTextContent('false')
+    expect(getByTestId('post-check')).toHaveTextContent('post-ok')
+    expect(queryByTestId('comment-check')).not.toBeInTheDocument()
+  })
+
+  it('hydrates through the factory overlay', async () => {
+    const server = createCore<{
+      post: ['create']
+    }>()
+    server.setup({
+      post: {
+        create: true,
+      },
+    })
+    const state = server.dehydrate()
+
+    const {
+      permix: client,
+      PermixProvider: BoundProvider,
+      PermixHydrate: BoundHydrate,
+      usePermix: useBoundPermix,
+    } = createPermix<{
+      post: ['create']
+    }>()
+
+    function Label() {
+      const { check, isReady } = useBoundPermix()
+      return (
+        <span data-testid="hydrate">{`${check('post.create')}:${isReady}`}</span>
+      )
+    }
+
+    const { getByTestId } = render(
+      <BoundProvider>
+        <BoundHydrate state={state}>
+          <Label />
+        </BoundHydrate>
+      </BoundProvider>
+    )
+
+    expect(getByTestId('hydrate')).toHaveTextContent('true:false')
+
+    client.setup({
+      post: {
+        create: true,
+      },
+    })
+
+    await waitFor(() => {
+      expect(getByTestId('hydrate')).toHaveTextContent('true:true')
+    })
+  })
+
+  it('throws in development when the singleton hook receives a different instance', () => {
+    const provided = createCore<{
+      post: ['read']
+    }>()
+    const other = createCore<{
+      post: ['read']
+    }>()
+
+    provided.setup({
+      post: {
+        read: true,
+      },
+    })
+
+    function Mismatch() {
+      const { check } = usePermix(other)
+      return <span>{check('post.read').toString()}</span>
+    }
+
+    expect(() =>
+      render(
+        <PermixProvider permix={provided}>
+          <Mismatch />
+        </PermixProvider>
+      )
+    ).toThrow(/same instance/)
+  })
+})

--- a/permix/src/react/create-permix.tsx
+++ b/permix/src/react/create-permix.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+
+import type { Definition, DehydratedState, Permix } from '../core'
+import { createPermix as createPermixCore } from '../core'
+import type { PermixComponents } from './components'
+import { createComponents, PermixHydrate, PermixProvider } from './components'
+import { createPermixContext, usePermix as usePermixFromContext } from './hooks'
+
+export interface CreatePermixResult<D extends Definition> {
+  permix: Permix<D>
+  PermixProvider: (props: { children: ReactNode }) => ReactNode
+  PermixHydrate: (props: {
+    children: ReactNode
+    state: DehydratedState<D>
+  }) => ReactNode
+  usePermix: () => {
+    check: Permix<D>['check']
+    isReady: boolean
+  }
+  Check: PermixComponents<D>['Check']
+}
+
+/**
+ * Create a Permix instance with isolated React bindings.
+ *
+ * Call once at module scope, same as `createPermix` from `permix/next` or
+ * `permix/express`. Pass an existing core instance to wrap it instead of
+ * creating a new one.
+ *
+ * @link https://permix.letstri.dev/docs/integrations/react
+ */
+export function createPermix<D extends Definition>(
+  instance?: Permix<D>
+): CreatePermixResult<D> {
+  const permix = instance ?? createPermixCore<D>()
+  const context = createPermixContext<D>()
+  const { Check } = createComponents(permix, context)
+
+  function BoundProvider({ children }: { children: ReactNode }) {
+    return (
+      <PermixProvider permix={permix} context={context}>
+        {children}
+      </PermixProvider>
+    )
+  }
+
+  function BoundHydrate({
+    children,
+    state,
+  }: {
+    children: ReactNode
+    state: DehydratedState<D>
+  }) {
+    return (
+      <PermixHydrate state={state} context={context}>
+        {children}
+      </PermixHydrate>
+    )
+  }
+
+  function useBoundPermix() {
+    return usePermixFromContext(permix, context)
+  }
+
+  BoundProvider.displayName = 'PermixProvider'
+  BoundHydrate.displayName = 'PermixHydrate'
+
+  return {
+    permix,
+    PermixProvider: BoundProvider,
+    PermixHydrate: BoundHydrate,
+    usePermix: useBoundPermix,
+    Check,
+  }
+}

--- a/permix/src/react/hooks.test.tsx
+++ b/permix/src/react/hooks.test.tsx
@@ -31,6 +31,37 @@ describe('permix react', () => {
     expect(result.current.check('post.read')).toBe(false)
   })
 
+  it('reads ready state on the first render when setup ran before subscribe', () => {
+    const permix = createPermix<{
+      post: ['create']
+    }>()
+
+    permix.setup({
+      post: {
+        create: true,
+      },
+    })
+
+    function TestComponent() {
+      const { isReady, check } = usePermix(permix)
+      return (
+        <div>
+          {isReady.toString()}:{check('post.create').toString()}
+        </div>
+      )
+    }
+
+    const { container } = render(
+      <React.StrictMode>
+        <PermixProvider permix={permix}>
+          <TestComponent />
+        </PermixProvider>
+      </React.StrictMode>
+    )
+
+    expect(container.firstChild).toHaveTextContent('true:true')
+  })
+
   it('should work with DOM rerender', async () => {
     const permix = createPermix<{
       post: [{ name: 'create'; type: { id: string } }, 'read']

--- a/permix/src/react/hooks.ts
+++ b/permix/src/react/hooks.ts
@@ -9,18 +9,26 @@ export interface PermixContext<T extends Definition> {
   rules: Rules<T> | null
 }
 
-export const Context = React.createContext<PermixContext<any>>(null!)
+export function createPermixContext<D extends Definition>() {
+  return React.createContext<PermixContext<D> | null>(null)
+}
 
-export function usePermixContext() {
-  const context = React.useContext(Context)
+export const Context = createPermixContext<Definition>()
 
-  if (!context) {
+export function usePermixContext<D extends Definition = Definition>(
+  context?: React.Context<PermixContext<D> | null>
+): PermixContext<D> {
+  const value = React.useContext(
+    context ?? (Context as React.Context<PermixContext<D> | null>)
+  )
+
+  if (!value) {
     throw new Error(
       '[Permix]: Looks like you forgot to wrap your app with <PermixProvider>'
     )
   }
 
-  return context
+  return value
 }
 
 /**
@@ -29,15 +37,25 @@ export function usePermixContext() {
  * @link https://permix.letstri.dev/docs/integrations/react
  */
 export function usePermix<T extends Definition>(
-  permix: Pick<Permix<T>, 'getRules' | 'check'>
+  permix: Pick<Permix<T>, 'getRules' | 'check'>,
+  context?: React.Context<PermixContext<T> | null>
 ) {
-  const { isReady, rules } = usePermixContext()
+  const { isReady, rules, permix: provided } = usePermixContext(context)
+
+  const nodeProcess = (
+    globalThis as typeof globalThis & {
+      process?: { env?: { NODE_ENV?: string } }
+    }
+  ).process
+
+  if (nodeProcess?.env?.NODE_ENV !== 'production' && provided !== permix) {
+    throw new Error(
+      '[Permix]: usePermix must receive the same instance passed to <PermixProvider>'
+    )
+  }
 
   const check: Permix<T>['check'] = React.useCallback(
-    (...args) =>
-      createCheck<T>(() => (rules ?? permix.getRules()) as Rules<T> | null)(
-        ...args
-      ),
+    (...args) => createCheck<T>(() => rules ?? permix.getRules())(...args),
     [rules, permix]
   )
 

--- a/permix/src/react/index.ts
+++ b/permix/src/react/index.ts
@@ -1,4 +1,7 @@
 export { createComponents, PermixHydrate, PermixProvider } from './components'
 export type { CheckProps, PermixComponents } from './components'
+export { createPermix } from './create-permix'
+export type { CreatePermixResult } from './create-permix'
 export { usePermix } from './hooks'
 export type { PermixContext } from './hooks'
+

--- a/permix/src/react/index.ts
+++ b/permix/src/react/index.ts
@@ -4,4 +4,3 @@ export { createPermix } from './create-permix'
 export type { CreatePermixResult } from './create-permix'
 export { usePermix } from './hooks'
 export type { PermixContext } from './hooks'
-

--- a/permix/src/react/use-effect-event-compat.test.tsx
+++ b/permix/src/react/use-effect-event-compat.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react'
+import * as React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { useEffectEvent } from './use-effect-event'
+
+describe('useEffectEvent compatibility', () => {
+  it('keeps a stable identity while reading the latest callback', () => {
+    const calls: string[] = []
+    const { rerender } = renderHook(
+      ({ value, prefix }: { value: string; prefix: string }) => {
+        const onValue = useEffectEvent((next: string) => {
+          calls.push(`${prefix}:${next}`)
+        })
+
+        React.useEffect(() => {
+          onValue(value)
+        }, [value])
+
+        return onValue
+      },
+      { initialProps: { value: 'light', prefix: 'initial' } }
+    )
+
+    rerender({ value: 'dark', prefix: 'latest' })
+
+    expect(calls).toStrictEqual(['initial:light', 'latest:dark'])
+  })
+})

--- a/permix/src/react/use-effect-event.ts
+++ b/permix/src/react/use-effect-event.ts
@@ -1,0 +1,29 @@
+import * as React from 'react'
+
+type EffectEventHook = <Arguments extends unknown[], Result>(
+  callback: (...arguments_: Arguments) => Result
+) => (...arguments_: Arguments) => Result
+
+function useEffectEventFallback<Arguments extends unknown[], Result>(
+  callback: (...arguments_: Arguments) => Result
+): (...arguments_: Arguments) => Result {
+  const callbackRef = React.useRef(callback)
+
+  React.useInsertionEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  return React.useCallback(
+    (...arguments_: Arguments) => callbackRef.current(...arguments_),
+    []
+  )
+}
+
+const nativeUseEffectEvent = (
+  React as typeof React & {
+    useEffectEvent?: EffectEventHook
+  }
+).useEffectEvent
+
+export const useEffectEvent: EffectEventHook =
+  nativeUseEffectEvent ?? useEffectEventFallback

--- a/permix/src/react/use-isomorphic-layout-effect.ts
+++ b/permix/src/react/use-isomorphic-layout-effect.ts
@@ -1,0 +1,4 @@
+import * as React from 'react'
+
+export const useLayoutEffect =
+  'window' in globalThis ? React.useLayoutEffect : React.useEffect

--- a/permix/test-d/public-api.ts
+++ b/permix/test-d/public-api.ts
@@ -1,0 +1,74 @@
+import type { CheckArgs } from 'permix'
+import { createPermix } from 'permix'
+import { createPermix as createDrizzlePermix } from 'permix/drizzle'
+import { createPermix as createDrizzleLegacyPermix } from 'permix/drizzle/legacy'
+import { createPermix as createEffectPermix } from 'permix/effect'
+import { createPermix as createElysiaPermix } from 'permix/elysia'
+import { createPermix as createExpressPermix } from 'permix/express'
+import { createPermix as createFastifyPermix } from 'permix/fastify'
+import { createPermix as createHonoPermix } from 'permix/hono'
+import { createPermix as createNextPermix } from 'permix/next'
+import { createPermix as createNodePermix } from 'permix/node'
+import { createPermix as createOrpcPermix } from 'permix/orpc'
+import { createComponents as createReactComponents } from 'permix/react'
+import { createPermix as createServerPermix } from 'permix/server'
+import { createComponents as createSolidComponents } from 'permix/solid'
+import { createComponents as createSvelteComponents } from 'permix/svelte'
+import { createPermix as createTanstackStartPermix } from 'permix/tanstack-start'
+import { createPermix as createTrpcPermix } from 'permix/trpc'
+import { createComponents as createVueComponents } from 'permix/vue'
+
+type PostDefinition = {
+  post: ['create', 'read']
+}
+
+const core = createPermix<PostDefinition>()
+const react = createReactComponents(core)
+const vue = createVueComponents(core)
+const trpc = createTrpcPermix<PostDefinition>()
+const orpc = createOrpcPermix<PostDefinition>()
+const express = createExpressPermix<PostDefinition>()
+const hono = createHonoPermix<PostDefinition>()
+const node = createNodePermix<PostDefinition>()
+const server = createServerPermix<PostDefinition>()
+const elysia = createElysiaPermix<PostDefinition>()
+const fastify = createFastifyPermix<PostDefinition>()
+const solid = createSolidComponents(core)
+const svelte = createSvelteComponents(core)
+const drizzle = createDrizzlePermix({})
+const drizzleLegacy = createDrizzleLegacyPermix({})
+const effect = createEffectPermix<PostDefinition>()
+const next = createNextPermix<PostDefinition>()
+const tanstackStart = createTanstackStartPermix<PostDefinition>()
+
+core.setup({
+  post: {
+    create: true,
+    read: true,
+  },
+})
+
+const checkArgs: CheckArgs<PostDefinition> = ['post.create']
+const allowed = core.check(...checkArgs)
+
+export {
+  allowed,
+  core,
+  drizzle,
+  drizzleLegacy,
+  effect,
+  elysia,
+  express,
+  fastify,
+  hono,
+  next,
+  node,
+  orpc,
+  react,
+  server,
+  solid,
+  svelte,
+  tanstackStart,
+  trpc,
+  vue,
+}

--- a/permix/test-d/public-api.ts
+++ b/permix/test-d/public-api.ts
@@ -11,8 +11,8 @@ import { createPermix as createNextPermix } from 'permix/next'
 import { createPermix as createNodePermix } from 'permix/node'
 import { createPermix as createOrpcPermix } from 'permix/orpc'
 import {
-    createComponents as createReactComponents,
-    createPermix as createReactPermix,
+  createComponents as createReactComponents,
+  createPermix as createReactPermix,
 } from 'permix/react'
 import { createPermix as createServerPermix } from 'permix/server'
 import { createComponents as createSolidComponents } from 'permix/solid'
@@ -59,26 +59,26 @@ type FactoryCheck = ReturnType<(typeof reactFactory)['usePermix']>['check']
 const factoryCheck: FactoryCheck = core.check
 
 export {
-    allowed,
-    core,
-    drizzle,
-    drizzleLegacy,
-    effect,
-    elysia,
-    express,
-    factoryCheck,
-    fastify,
-    hono,
-    next,
-    node,
-    orpc,
-    react,
-    reactFactory,
-    reactStandalone,
-    server,
-    solid,
-    svelte,
-    tanstackStart,
-    trpc,
-    vue
+  allowed,
+  core,
+  drizzle,
+  drizzleLegacy,
+  effect,
+  elysia,
+  express,
+  factoryCheck,
+  fastify,
+  hono,
+  next,
+  node,
+  orpc,
+  react,
+  reactFactory,
+  reactStandalone,
+  server,
+  solid,
+  svelte,
+  tanstackStart,
+  trpc,
+  vue,
 }

--- a/permix/test-d/public-api.ts
+++ b/permix/test-d/public-api.ts
@@ -87,4 +87,3 @@ export {
   trpc,
   vue,
 }
-

--- a/permix/test-d/public-api.ts
+++ b/permix/test-d/public-api.ts
@@ -10,7 +10,10 @@ import { createPermix as createHonoPermix } from 'permix/hono'
 import { createPermix as createNextPermix } from 'permix/next'
 import { createPermix as createNodePermix } from 'permix/node'
 import { createPermix as createOrpcPermix } from 'permix/orpc'
-import { createComponents as createReactComponents } from 'permix/react'
+import {
+    createComponents as createReactComponents,
+    createPermix as createReactPermix,
+} from 'permix/react'
 import { createPermix as createServerPermix } from 'permix/server'
 import { createComponents as createSolidComponents } from 'permix/solid'
 import { createComponents as createSvelteComponents } from 'permix/svelte'
@@ -24,6 +27,8 @@ type PostDefinition = {
 
 const core = createPermix<PostDefinition>()
 const react = createReactComponents(core)
+const reactFactory = createReactPermix(core)
+const reactStandalone = createReactPermix<PostDefinition>()
 const vue = createVueComponents(core)
 const trpc = createTrpcPermix<PostDefinition>()
 const orpc = createOrpcPermix<PostDefinition>()
@@ -50,25 +55,30 @@ core.setup({
 
 const checkArgs: CheckArgs<PostDefinition> = ['post.create']
 const allowed = core.check(...checkArgs)
+type FactoryCheck = ReturnType<(typeof reactFactory)['usePermix']>['check']
+const factoryCheck: FactoryCheck = core.check
 
 export {
-  allowed,
-  core,
-  drizzle,
-  drizzleLegacy,
-  effect,
-  elysia,
-  express,
-  fastify,
-  hono,
-  next,
-  node,
-  orpc,
-  react,
-  server,
-  solid,
-  svelte,
-  tanstackStart,
-  trpc,
-  vue,
+    allowed,
+    core,
+    drizzle,
+    drizzleLegacy,
+    effect,
+    elysia,
+    express,
+    factoryCheck,
+    fastify,
+    hono,
+    next,
+    node,
+    orpc,
+    react,
+    reactFactory,
+    reactStandalone,
+    server,
+    solid,
+    svelte,
+    tanstackStart,
+    trpc,
+    vue
 }

--- a/permix/test-d/public-api.ts
+++ b/permix/test-d/public-api.ts
@@ -43,7 +43,12 @@ const svelte = createSvelteComponents(core)
 const drizzle = createDrizzlePermix({})
 const drizzleLegacy = createDrizzleLegacyPermix({})
 const effect = createEffectPermix<PostDefinition>()
-const next = createNextPermix<PostDefinition>()
+const next = createNextPermix<PostDefinition>(() => ({
+  post: {
+    create: true,
+    read: true,
+  },
+}))
 const tanstackStart = createTanstackStartPermix<PostDefinition>()
 
 core.setup({
@@ -82,3 +87,4 @@ export {
     trpc,
     vue
 }
+

--- a/permix/test/next/.gitignore
+++ b/permix/test/next/.gitignore
@@ -1,0 +1,4 @@
+.scratch
+test-results
+playwright-report
+blob-report

--- a/permix/test/next/instant-nav.rig.md
+++ b/permix/test/next/instant-nav.rig.md
@@ -1,0 +1,10 @@
+# instant-nav rig: permix Next.js adapter fixtures
+
+- BUILD: `EXPOSE_TESTING_API=1` plus the versioned `next` binary from this package (`next-15`, `next-16-0`, `next-16-3`) run as `next build && next start` inside `permix/test/next/.scratch/<version>`. Never `next dev`.
+- EXPOSE: `EXPOSE_TESTING_API=1` at **build** time, wired to `experimental.exposeTestingApiInProductionBuild` in the 16.3 overlay config. Compat versions (15.5.24, 16.0.11) do not run `instant()`.
+- RUN: `pnpm --filter @permix/next-integration test` (or `node permix/test/next/run.mjs` after `pnpm --filter permix build`). Playwright uses `BASE_URL` from the launcher. Desktop 1280×720 and mobile 390×844 projects run the 16.3 instant-navigation file.
+- TEST USER: cookie `demo-user=alice` (can create/update) or `demo-user=bob` (read only). No login helper; tests call `context.addCookies`. Public/cache-safe checks do not depend on the cookie.
+- DRIFT: cookie value, tenant root param (`acme` vs `globex`), whether a `"use cache: private"` payload was primed, Partial Prefetching vs `prefetch={true}`. The cold session island uses `connection()` so the testing lock can gate it; cookie reads alone are not a lock probe.
+- LOOP: local `build → start → playwright` via `run.mjs`; CI job `.github/workflows/next-integration.yml` does the same. Fully agent-drivable; no secrets.
+- LIVENESS: n/a — each run builds and starts a local server on a free port, then stops that process group.
+- WALLS: `permix` must be built (`pnpm --filter permix build`) so the fixture can import `permix`/`permix/next`. Playwright Chromium is installed with `pnpm exec playwright install chromium`. Next 15/16.0 configs must not set `cacheComponents` or `partialPrefetching`.

--- a/permix/test/next/package.json
+++ b/permix/test/next/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@permix/next-integration",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node ./run.mjs"
+  },
+  "dependencies": {
+    "permix": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@next/playwright": "16.3.3",
+    "@playwright/test": "^1.55.1",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "next-15": "npm:next@15.5.24",
+    "next-16-0": "npm:next@16.0.11",
+    "next-16-3": "npm:next@16.3.3",
+    "typescript": "catalog:",
+    "typescript59": "catalog:typescript-classic"
+  }
+}

--- a/permix/test/next/playwright.config.ts
+++ b/permix/test/next/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from '@playwright/test'
+
+const baseURL = process.env.BASE_URL ?? 'http://127.0.0.1:3000'
+const isPpr = process.env.PERMIX_NEXT_VERSION === '16.3.3'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  use: {
+    baseURL,
+    trace: 'off',
+  },
+  projects: [
+    {
+      name: 'compat',
+      testMatch: /compat\.spec\.ts/,
+      use: { viewport: { width: 1280, height: 720 } },
+    },
+    ...(isPpr
+      ? [
+          {
+            name: 'desktop',
+            testMatch: /instant\.spec\.ts/,
+            use: { viewport: { width: 1280, height: 720 } },
+          },
+          {
+            name: 'mobile',
+            testMatch: /instant\.spec\.ts/,
+            use: { viewport: { width: 390, height: 844 } },
+          },
+        ]
+      : []),
+  ],
+})

--- a/permix/test/next/run.mjs
+++ b/permix/test/next/run.mjs
@@ -1,0 +1,183 @@
+import { spawn } from 'node:child_process'
+import { cp, mkdir, rm, symlink } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { createServer } from 'node:net'
+import path from 'node:path'
+
+const here = import.meta.dirname
+const require = createRequire(import.meta.url)
+const permixRoot = path.resolve(here, '../..')
+
+const versions = [
+  { id: '15.5.24', alias: 'next-15', ppr: false, typescript: 'typescript59' },
+  { id: '16.0.11', alias: 'next-16-0', ppr: false, typescript: 'typescript59' },
+  { id: '16.3.3', alias: 'next-16-3', ppr: true, typescript: 'typescript' },
+]
+
+function packageDir(specifier) {
+  return path.dirname(require.resolve(`${specifier}/package.json`))
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close()
+        reject(new Error('Failed to allocate a port'))
+        return
+      }
+      const port = address.port
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(port)
+      })
+    })
+    server.on('error', reject)
+  })
+}
+
+function run(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      ...options,
+    })
+    child.on('error', reject)
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(
+        new Error(`${command} ${args.join(' ')} failed (${code ?? signal})`)
+      )
+    })
+  })
+}
+
+async function waitForServer(url, timeoutMs = 60_000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url, { redirect: 'manual' })
+      await response.arrayBuffer()
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+  throw new Error(`Timed out waiting for ${url}`)
+}
+
+async function prepare(version) {
+  const dest = path.join(here, '.scratch', version.id)
+  await rm(dest, { recursive: true, force: true })
+  await cp(path.join(here, 'src'), dest, { recursive: true })
+  if (version.ppr) {
+    await cp(path.join(here, 'src-ppr'), dest, { recursive: true })
+    await rm(path.join(dest, 'app/layout.tsx'), { force: true })
+    await rm(path.join(dest, 'app/page.tsx'), { force: true })
+  }
+
+  const modules = path.join(dest, 'node_modules')
+  await mkdir(modules, { recursive: true })
+  await symlink(packageDir(version.alias), path.join(modules, 'next'))
+  await symlink(packageDir('react'), path.join(modules, 'react'))
+  await symlink(packageDir('react-dom'), path.join(modules, 'react-dom'))
+  await symlink(packageDir(version.typescript), path.join(modules, 'typescript'))
+  await symlink(permixRoot, path.join(modules, 'permix'))
+  return dest
+}
+
+async function nextBin(alias) {
+  const nextPackage = packageDir(alias)
+  return path.join(nextPackage, 'dist/bin/next')
+}
+
+async function withServer(version, dest, fn) {
+  const port = await getFreePort()
+  const baseURL = `http://127.0.0.1:${port}`
+  const bin = await nextBin(version.alias)
+  const child = spawn(process.execPath, [bin, 'start', '-p', String(port)], {
+    cwd: dest,
+    env: { ...process.env, PORT: String(port) },
+    stdio: 'inherit',
+    detached: process.platform !== 'win32',
+  })
+
+  const stop = async () => {
+    if (child.pid && process.platform !== 'win32') {
+      try {
+        process.kill(-child.pid, 'SIGTERM')
+      } catch {
+        child.kill('SIGTERM')
+      }
+    } else {
+      child.kill('SIGTERM')
+    }
+  }
+
+  try {
+    await waitForServer(baseURL)
+    await fn(baseURL)
+  } finally {
+    await stop()
+  }
+}
+
+async function main() {
+  const dist = path.join(permixRoot, 'dist/core/index.mjs')
+  try {
+    await import(path.join(permixRoot, 'dist/next/index.mjs'))
+  } catch {
+    throw new Error(
+      `permix must be built before running Next fixtures (missing ${dist}). Run pnpm --filter permix build.`
+    )
+  }
+
+  const only = process.env.PERMIX_NEXT_VERSION
+  const selected = only
+    ? versions.filter((version) => version.id === only)
+    : versions
+  if (only && selected.length === 0) {
+    throw new Error(`Unknown PERMIX_NEXT_VERSION: ${only}`)
+  }
+
+  for (const version of selected) {
+    console.log(`\n=== Next ${version.id} ===`)
+    const dest = await prepare(version)
+    const bin = await nextBin(version.alias)
+    await run(process.execPath, [bin, 'build'], {
+      cwd: dest,
+      env: {
+        ...process.env,
+        EXPOSE_TESTING_API: '1',
+        PERMIX_NEXT_VERSION: version.id,
+      },
+    })
+    await withServer(version, dest, async (baseURL) => {
+      await run(
+        'pnpm',
+        ['exec', 'playwright', 'test', '--config', 'playwright.config.ts'],
+        {
+          cwd: here,
+          env: {
+            ...process.env,
+            BASE_URL: baseURL,
+            PERMIX_NEXT_VERSION: version.id,
+          },
+        }
+      )
+    })
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/permix/test/next/src-ppr/app/[tenant]/dashboard/page.tsx
+++ b/permix/test/next/src-ppr/app/[tenant]/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import { PermissionHoles } from '../../features/permission-holes'
+
+export default function DashboardPage() {
+  return (
+    <main>
+      <h1 data-testid="dashboard-shell">Dashboard</h1>
+      <PermissionHoles />
+    </main>
+  )
+}

--- a/permix/test/next/src-ppr/app/[tenant]/layout.tsx
+++ b/permix/test/next/src-ppr/app/[tenant]/layout.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+
+import { CacheSafeCheck } from '../features/cache-safe-check'
+
+export function generateStaticParams() {
+  return [{ tenant: 'acme' }, { tenant: 'globex' }]
+}
+
+export default function TenantLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ tenant: string }>
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <header data-testid="app-shell">Permix Next fixture</header>
+        <section>
+          <nav data-testid="tenant-shell">
+            {params.then(({ tenant }) => (
+              <span data-testid="tenant-name">{tenant}</span>
+            ))}
+            <Link href="/acme" data-testid="acme-link">
+              Acme
+            </Link>
+            <Link href="/globex" data-testid="globex-link">
+              Globex
+            </Link>
+            <Link href="/acme/dashboard" data-testid="dashboard-link">
+              Dashboard
+            </Link>
+            <Link
+              href="/acme/dashboard"
+              prefetch
+              data-testid="dashboard-prefetch-link"
+            >
+              Dashboard (prefetch)
+            </Link>
+            <Link href="/globex" prefetch data-testid="globex-prefetch-link">
+              Globex (prefetch)
+            </Link>
+          </nav>
+          <Suspense
+            fallback={
+              <p data-testid="cache-safe-fallback">loading cache-safe</p>
+            }
+          >
+            <CacheSafeCheck />
+          </Suspense>
+          {children}
+        </section>
+      </body>
+    </html>
+  )
+}

--- a/permix/test/next/src-ppr/app/[tenant]/page.tsx
+++ b/permix/test/next/src-ppr/app/[tenant]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from 'react'
+
+import { ActionCheck } from '../features/action-check'
+import { ConcurrentInstances } from '../features/concurrent-instances'
+import { PermissionHoles } from '../features/permission-holes'
+import { PublicRead } from '../features/public-read'
+import { SessionCreate } from '../features/session-create'
+import { UsePermixCreate } from '../features/use-permix-create'
+
+export default function TenantHome({
+  params,
+}: {
+  params: Promise<{ tenant: string }>
+}) {
+  return (
+    <main>
+      {params.then(({ tenant }) => (
+        <h1 data-testid="tenant-home" data-tenant={tenant}>
+          Tenant home
+        </h1>
+      ))}
+      <Suspense fallback={<p data-testid="public-fallback">loading public</p>}>
+        <PublicRead />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="concurrent-fallback">loading instances</p>}
+      >
+        <ConcurrentInstances />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="session-fallback">loading session</p>}
+      >
+        <SessionCreate />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="use-permix-fallback">loading usePermix</p>}
+      >
+        <UsePermixCreate />
+      </Suspense>
+      <ActionCheck />
+      <PermissionHoles />
+    </main>
+  )
+}

--- a/permix/test/next/src-ppr/app/features/cache-safe-check.tsx
+++ b/permix/test/next/src-ppr/app/features/cache-safe-check.tsx
@@ -1,0 +1,13 @@
+import { tenant } from 'next/root-params'
+
+import { tenantPermix } from '../../lib/tenant-permix'
+
+export async function CacheSafeCheck() {
+  const current = await tenant()
+  const canCreate = await tenantPermix.check('post.create')
+  return (
+    <span data-testid="cache-safe-check">
+      {current}:{canCreate ? 'create-allowed' : 'create-denied'}
+    </span>
+  )
+}

--- a/permix/test/next/src-ppr/app/features/permission-holes.tsx
+++ b/permix/test/next/src-ppr/app/features/permission-holes.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+
+import { PrivateEdit } from './private-edit'
+import { SessionIsland } from './session-island'
+
+export function PermissionHoles() {
+  return (
+    <>
+      <Suspense
+        fallback={<p data-testid="session-island-fallback">loading session</p>}
+      >
+        <SessionIsland />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="private-edit-fallback">loading private</p>}
+      >
+        <PrivateEdit />
+      </Suspense>
+    </>
+  )
+}

--- a/permix/test/next/src-ppr/app/features/private-edit.tsx
+++ b/permix/test/next/src-ppr/app/features/private-edit.tsx
@@ -1,0 +1,24 @@
+import { createPermix } from 'permix'
+
+import { getUser } from '../../lib/auth'
+import type { PostDefinition } from '../../lib/permix'
+import { rulesForUser } from '../../lib/permix'
+
+async function readPrivateEditPayload() {
+  'use cache: private'
+  const user = await getUser()
+  const permix = createPermix<PostDefinition>()
+  permix.setup(rulesForUser(user))
+  if (!permix.check('post.update')) {
+    return null
+  }
+  return { canEdit: true as const, user }
+}
+
+export async function PrivateEdit() {
+  const payload = await readPrivateEditPayload()
+  if (!payload) {
+    return <span data-testid="private-edit">hidden</span>
+  }
+  return <span data-testid="private-edit">{payload.user}:edit-allowed</span>
+}

--- a/permix/test/next/src-ppr/app/features/session-island.tsx
+++ b/permix/test/next/src-ppr/app/features/session-island.tsx
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+
+import { permix } from '../../lib/permix'
+
+export async function SessionIsland() {
+  await connection()
+  const allowed = await permix.check('post.create')
+  return (
+    <span data-testid="session-island">
+      {allowed ? 'session-allowed' : 'session-denied'}
+    </span>
+  )
+}

--- a/permix/test/next/src-ppr/lib/tenant-permix.ts
+++ b/permix/test/next/src-ppr/lib/tenant-permix.ts
@@ -1,0 +1,15 @@
+import { tenant } from 'next/root-params'
+import { createPermix } from 'permix/next'
+
+import type { PostDefinition } from './permix'
+
+export const tenantPermix = createPermix<PostDefinition>(async () => {
+  const current = await tenant()
+  return {
+    post: {
+      create: current === 'acme',
+      read: true,
+      update: false,
+    },
+  }
+})

--- a/permix/test/next/src-ppr/next.config.mjs
+++ b/permix/test/next/src-ppr/next.config.mjs
@@ -1,0 +1,18 @@
+const exposeTestingApi = process.env.EXPOSE_TESTING_API === '1'
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ['permix'],
+  cacheComponents: true,
+  partialPrefetching: true,
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  experimental: exposeTestingApi
+    ? {
+        exposeTestingApiInProductionBuild: true,
+      }
+    : undefined,
+}
+
+export default nextConfig

--- a/permix/test/next/src-ppr/root-params.d.ts
+++ b/permix/test/next/src-ppr/root-params.d.ts
@@ -1,0 +1,3 @@
+declare module 'next/root-params' {
+  export function tenant(): Promise<string>
+}

--- a/permix/test/next/src/app/actions.ts
+++ b/permix/test/next/src/app/actions.ts
@@ -1,0 +1,13 @@
+'use server'
+
+import { createPermix } from 'permix'
+
+import { getUser } from '../lib/auth'
+import type { PostDefinition } from '../lib/permix'
+import { rulesForUser } from '../lib/permix'
+
+export async function checkCreate() {
+  const permix = createPermix<PostDefinition>()
+  permix.setup(rulesForUser(await getUser()))
+  return permix.check('post.create')
+}

--- a/permix/test/next/src/app/api/check/route.ts
+++ b/permix/test/next/src/app/api/check/route.ts
@@ -1,0 +1,14 @@
+import { createPermix } from 'permix'
+
+import { getUser } from '../../../lib/auth'
+import type { PostDefinition } from '../../../lib/permix'
+import { rulesForUser } from '../../../lib/permix'
+
+export async function GET() {
+  const permix = createPermix<PostDefinition>()
+  permix.setup(rulesForUser(await getUser()))
+  return Response.json({
+    create: permix.check('post.create'),
+    read: permix.check('post.read'),
+  })
+}

--- a/permix/test/next/src/app/features/action-check.tsx
+++ b/permix/test/next/src/app/features/action-check.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useState } from 'react'
+
+import { checkCreate } from '../actions'
+
+export function ActionCheck() {
+  const [result, setResult] = useState<string>('idle')
+
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="action-check"
+        onClick={async () => {
+          const allowed = await checkCreate()
+          setResult(allowed ? 'allowed' : 'denied')
+        }}
+      >
+        Check via action
+      </button>
+      <span data-testid="action-result">{result}</span>
+    </div>
+  )
+}

--- a/permix/test/next/src/app/features/concurrent-instances.tsx
+++ b/permix/test/next/src/app/features/concurrent-instances.tsx
@@ -1,0 +1,16 @@
+import { instanceId } from '../../lib/instance-id'
+import { permix } from '../../lib/permix'
+
+export async function ConcurrentInstances() {
+  return (
+    <div>
+      <InstanceSlot testId="instance-a" />
+      <InstanceSlot testId="instance-b" />
+    </div>
+  )
+}
+
+async function InstanceSlot({ testId }: { testId: string }) {
+  const instance = await permix.getPermix()
+  return <span data-testid={testId}>{String(instanceId(instance))}</span>
+}

--- a/permix/test/next/src/app/features/public-read.tsx
+++ b/permix/test/next/src/app/features/public-read.tsx
@@ -1,0 +1,6 @@
+import { publicPermix } from '../../lib/permix'
+
+export async function PublicRead() {
+  const allowed = await publicPermix.check('post.read')
+  return <span data-testid="public-read">{allowed ? 'allowed' : 'denied'}</span>
+}

--- a/permix/test/next/src/app/features/session-create.tsx
+++ b/permix/test/next/src/app/features/session-create.tsx
@@ -1,0 +1,8 @@
+import { permix } from '../../lib/permix'
+
+export async function SessionCreate() {
+  const allowed = await permix.check('post.create')
+  return (
+    <span data-testid="session-create">{allowed ? 'allowed' : 'denied'}</span>
+  )
+}

--- a/permix/test/next/src/app/features/use-permix-create.tsx
+++ b/permix/test/next/src/app/features/use-permix-create.tsx
@@ -1,0 +1,10 @@
+import { permix } from '../../lib/permix'
+
+export function UsePermixCreate() {
+  const instance = permix.usePermix()
+  return (
+    <span data-testid="use-permix-create">
+      {instance.check('post.create') ? 'allowed' : 'denied'}
+    </span>
+  )
+}

--- a/permix/test/next/src/app/layout.tsx
+++ b/permix/test/next/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <header data-testid="app-shell">Permix Next fixture</header>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/permix/test/next/src/app/page.tsx
+++ b/permix/test/next/src/app/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react'
+
+import { ActionCheck } from './features/action-check'
+import { ConcurrentInstances } from './features/concurrent-instances'
+import { PublicRead } from './features/public-read'
+import { SessionCreate } from './features/session-create'
+import { UsePermixCreate } from './features/use-permix-create'
+
+export default function Home() {
+  return (
+    <main>
+      <Suspense fallback={<p data-testid="public-fallback">loading public</p>}>
+        <PublicRead />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="concurrent-fallback">loading instances</p>}
+      >
+        <ConcurrentInstances />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="session-fallback">loading session</p>}
+      >
+        <SessionCreate />
+      </Suspense>
+      <Suspense
+        fallback={<p data-testid="use-permix-fallback">loading usePermix</p>}
+      >
+        <UsePermixCreate />
+      </Suspense>
+      <ActionCheck />
+    </main>
+  )
+}

--- a/permix/test/next/src/lib/auth.ts
+++ b/permix/test/next/src/lib/auth.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers'
+
+export type DemoUser = 'alice' | 'bob'
+
+export async function getUser(): Promise<DemoUser> {
+  const store = await cookies()
+  const value = store.get('demo-user')?.value
+  return value === 'bob' ? 'bob' : 'alice'
+}

--- a/permix/test/next/src/lib/instance-id.ts
+++ b/permix/test/next/src/lib/instance-id.ts
@@ -1,0 +1,12 @@
+const ids = new WeakMap<object, number>()
+let sequence = 0
+
+export function instanceId(value: object): number {
+  const existing = ids.get(value)
+  if (existing !== undefined) {
+    return existing
+  }
+  sequence += 1
+  ids.set(value, sequence)
+  return sequence
+}

--- a/permix/test/next/src/lib/permix.ts
+++ b/permix/test/next/src/lib/permix.ts
@@ -1,0 +1,29 @@
+import { createPermix } from 'permix/next'
+
+import { getUser } from './auth'
+
+export type PostDefinition = {
+  post: ['create', 'read', 'update']
+}
+
+export function rulesForUser(user: 'alice' | 'bob') {
+  return {
+    post: {
+      create: user === 'alice',
+      read: true,
+      update: user === 'alice',
+    },
+  } as const
+}
+
+export const permix = createPermix<PostDefinition>(async () =>
+  rulesForUser(await getUser())
+)
+
+export const publicPermix = createPermix<PostDefinition>(() => ({
+  post: {
+    create: false,
+    read: true,
+    update: false,
+  },
+}))

--- a/permix/test/next/src/next-env.d.ts
+++ b/permix/test/next/src/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/permix/test/next/src/next.config.mjs
+++ b/permix/test/next/src/next.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ['permix'],
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+}
+
+export default nextConfig

--- a/permix/test/next/src/package.json
+++ b/permix/test/next/src/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "permix-next-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/permix/test/next/src/tsconfig.json
+++ b/permix/test/next/src/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "resolveJsonModule": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/permix/test/next/tests/compat.spec.ts
+++ b/permix/test/next/tests/compat.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const homePath =
+  process.env.PERMIX_NEXT_VERSION === '16.3.3' ? '/acme' : '/'
+
+async function setUser(page: Page, user: 'alice' | 'bob') {
+  const baseURL = test.info().project.use.baseURL
+  if (!baseURL) {
+    throw new Error('BASE_URL is required')
+  }
+  const url = new URL(baseURL)
+  await page.context().addCookies([
+    {
+      name: 'demo-user',
+      value: user,
+      domain: url.hostname,
+      path: '/',
+    },
+  ])
+}
+
+test.describe('next adapter request state', () => {
+  test('concurrent RSC callers share one initialized instance', async ({
+    page,
+  }) => {
+    await setUser(page, 'alice')
+    await page.goto(homePath)
+    await expect(page.getByTestId('instance-a')).not.toHaveText('')
+    await expect(page.getByTestId('instance-b')).toHaveText(
+      await page.getByTestId('instance-a').innerText()
+    )
+    await expect(page.getByTestId('use-permix-create')).toHaveText('allowed')
+    await expect(page.getByTestId('session-create')).toHaveText('allowed')
+    await expect(page.getByTestId('public-read')).toHaveText('allowed')
+  })
+
+  test('concurrent requests stay isolated', async ({ browser, baseURL }) => {
+    if (!baseURL) {
+      throw new Error('BASE_URL is required')
+    }
+    const url = new URL(baseURL)
+
+    async function openAs(user: 'alice' | 'bob') {
+      const context = await browser.newContext()
+      await context.addCookies([
+        {
+          name: 'demo-user',
+          value: user,
+          domain: url.hostname,
+          path: '/',
+        },
+      ])
+      const page = await context.newPage()
+      await page.goto(homePath)
+      return { context, page }
+    }
+
+    const alice = await openAs('alice')
+    const bob = await openAs('bob')
+
+    await expect(alice.page.getByTestId('session-create')).toHaveText('allowed')
+    await expect(bob.page.getByTestId('session-create')).toHaveText('denied')
+    await expect(alice.page.getByTestId('use-permix-create')).toHaveText(
+      'allowed'
+    )
+    await expect(bob.page.getByTestId('use-permix-create')).toHaveText('denied')
+
+    await alice.context.close()
+    await bob.context.close()
+  })
+
+  test('route handler sets up an explicit core instance', async ({
+    page,
+    baseURL,
+  }) => {
+    await setUser(page, 'alice')
+    const alice = await page.request.get(`${baseURL}/api/check`)
+    expect(await alice.json()).toEqual({ create: true, read: true })
+
+    await page.context().clearCookies()
+    await setUser(page, 'bob')
+    const bob = await page.request.get(`${baseURL}/api/check`)
+    expect(await bob.json()).toEqual({ create: false, read: true })
+  })
+
+  test('server action sets up an explicit core instance', async ({ page }) => {
+    await setUser(page, 'alice')
+    await page.goto(homePath)
+    await page.getByTestId('action-check').click()
+    await expect(page.getByTestId('action-result')).toHaveText('allowed')
+
+    await page.context().clearCookies()
+    await setUser(page, 'bob')
+    await page.reload()
+    await page.getByTestId('action-check').click()
+    await expect(page.getByTestId('action-result')).toHaveText('denied')
+  })
+})

--- a/permix/test/next/tests/instant.spec.ts
+++ b/permix/test/next/tests/instant.spec.ts
@@ -1,0 +1,103 @@
+import { instant } from '@next/playwright'
+import { expect, test, type Page } from '@playwright/test'
+
+async function setUser(page: Page, user: 'alice' | 'bob') {
+  const baseURL = test.info().project.use.baseURL
+  if (!baseURL) {
+    throw new Error('BASE_URL is required')
+  }
+  const url = new URL(baseURL)
+  await page.context().addCookies([
+    {
+      name: 'demo-user',
+      value: user,
+      domain: url.hostname,
+      path: '/',
+    },
+  ])
+}
+
+function dashboardMain(page: Page) {
+  return page
+    .locator('main')
+    .filter({ has: page.getByTestId('dashboard-shell') })
+}
+
+test.describe('next 16.3 instant navigation', () => {
+  test('cache-safe permission UI is present under the lock', async ({
+    page,
+    baseURL,
+  }) => {
+    await setUser(page, 'alice')
+    await instant(
+      page,
+      async () => {
+        await page.goto('/acme')
+        await expect(page.getByTestId('app-shell')).toBeVisible()
+        await expect(page.getByTestId('tenant-shell')).toBeVisible()
+        await expect(page.getByText('acme:create-allowed')).toBeVisible()
+      },
+      { baseURL }
+    )
+  })
+
+  test('cold session island is gated then streams', async ({ page }) => {
+    await setUser(page, 'alice')
+    await page.goto('/acme')
+    await expect(page.getByTestId('tenant-home')).toBeVisible()
+
+    const dest = dashboardMain(page)
+    await instant(page, async () => {
+      await page.getByTestId('dashboard-link').click()
+      await expect(dest.getByTestId('dashboard-shell')).toBeVisible()
+      await expect(dest.getByTestId('session-island')).toHaveCount(0)
+    })
+
+    await expect(dest.getByTestId('session-island')).toBeVisible()
+  })
+
+  test('primed private payload is present immediately', async ({ page }) => {
+    await setUser(page, 'alice')
+    await page.goto('/acme')
+    await expect(page.getByTestId('private-edit')).toHaveText(
+      'alice:edit-allowed'
+    )
+
+    const dest = dashboardMain(page)
+    await instant(page, async () => {
+      await page.getByTestId('dashboard-prefetch-link').click()
+      await expect(dest.getByTestId('dashboard-shell')).toBeVisible()
+      await expect(dest.getByTestId('private-edit')).toHaveText(
+        'alice:edit-allowed'
+      )
+    })
+  })
+
+  test('default shared-shell navigation keeps tenant chrome instant', async ({
+    page,
+  }) => {
+    await setUser(page, 'alice')
+    await page.goto('/acme')
+    await expect(page.getByTestId('tenant-home')).toBeVisible()
+
+    await instant(page, async () => {
+      await page.getByTestId('globex-link').click()
+      await expect(page.getByTestId('tenant-shell')).toBeVisible()
+      await expect(page.getByText('globex:create-denied')).toBeVisible()
+    })
+  })
+
+  test('prefetch=true root-param navigation includes tenant-keyed UI', async ({
+    page,
+  }) => {
+    await setUser(page, 'alice')
+    await page.goto('/acme')
+    await expect(page.getByTestId('tenant-home')).toBeVisible()
+
+    await instant(page, async () => {
+      await page.getByTestId('globex-prefetch-link').click()
+      await expect(page.getByTestId('tenant-shell')).toBeVisible()
+      await expect(page.getByText('globex:create-denied')).toBeVisible()
+    })
+  })
+})

--- a/permix/tsconfig.base.json
+++ b/permix/tsconfig.base.json
@@ -1,13 +1,27 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "lib": ["ESNext"],
     "jsx": "preserve",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "moduleDetection": "force",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true,
     "noEmit": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": []
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "*.ts"],
   "exclude": [
@@ -20,6 +34,8 @@
     "src/tanstack-start/*.ts",
     "src/tanstack-start/*.tsx",
     "src/svelte/**/*.ts",
-    "src/svelte/**/*.svelte"
+    "src/svelte/**/*.svelte",
+    "test-d/**",
+    "scripts/**"
   ]
 }

--- a/permix/tsconfig.compat.json
+++ b/permix/tsconfig.compat.json
@@ -7,12 +7,19 @@
     "moduleDetection": "force",
     "strict": true,
     "exactOptionalPropertyTypes": true,
-    "noEmit": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noUncheckedSideEffectImports": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
     "skipLibCheck": true,
-    "types": [],
-    "verbatimModuleSyntax": true
+    "types": []
   },
   "include": ["test-d/**/*.ts"]
 }

--- a/permix/tsconfig.compat.json
+++ b/permix/tsconfig.compat.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": true,
+    "types": [],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["test-d/**/*.ts"]
+}

--- a/permix/tsconfig.react.json
+++ b/permix/tsconfig.react.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": []
   },
   "include": [
     "src/react/*.ts",

--- a/permix/tsconfig.solid.json
+++ b/permix/tsconfig.solid.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "solid-js",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": []
   },
   "include": ["src/solid/*.ts", "src/solid/*.tsx"],
   "exclude": ["src/react/*.ts", "src/react/*.tsx"]

--- a/permix/vitest.config.ts
+++ b/permix/vitest.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
   ],
   test: {
     environment: 'happy-dom',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/.svelte-kit/**'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.svelte-kit/**',
+      '**/test/next/**',
+    ],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,61 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/node':
+      specifier: ^25.9.1
+      version: 25.9.1
+    '@types/react':
+      specifier: ^19.2.15
+      version: 19.2.15
+    '@types/react-dom':
+      specifier: ^19.2.3
+      version: 19.2.3
+    '@vitejs/plugin-react':
+      specifier: ^6.0.2
+      version: 6.0.2
+    oxfmt:
+      specifier: ^0.64.0
+      version: 0.64.0
+    oxlint:
+      specifier: ^1.79.0
+      version: 1.80.0
+    oxlint-tsgolint:
+      specifier: ^7.0.2001
+      version: 7.0.2001
+    react:
+      specifier: ^19.2.6
+      version: 19.2.6
+    react-dom:
+      specifier: ^19.2.6
+      version: 19.2.6
+    tsx:
+      specifier: ^4.22.4
+      version: 4.22.4
+    turbo:
+      specifier: 2.10.12
+      version: 2.10.12
+    typescript:
+      specifier: 7.0.2
+      version: 7.0.2
+    ultracite:
+      specifier: ^7.10.6
+      version: 7.10.6
+    vite:
+      specifier: ^8.0.16
+      version: 8.0.16
+    vitest:
+      specifier: ^4.1.8
+      version: 4.1.8
+  typescript-classic:
+    typescript59:
+      specifier: npm:typescript@5.9.3
+      version: 5.9.3
+    typescript6:
+      specifier: npm:@typescript/typescript6@6.0.2
+      version: 6.0.2
+
 importers:
 
   .:
@@ -15,25 +70,25 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       oxfmt:
-        specifier: ^0.64.0
+        specifier: 'catalog:'
         version: 0.64.0(svelte@5.56.0)
       oxlint:
-        specifier: ^1.79.0
+        specifier: 'catalog:'
         version: 1.80.0(oxlint-tsgolint@7.0.2001)
       oxlint-tsgolint:
-        specifier: ^7.0.2001
+        specifier: 'catalog:'
         version: 7.0.2001
       taze:
         specifier: ^19.14.1
         version: 19.14.1
       turbo:
-        specifier: ^2.9.16
-        version: 2.9.16
+        specifier: 'catalog:'
+        version: 2.10.12
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       ultracite:
-        specifier: ^7.10.6
+        specifier: 'catalog:'
         version: 7.10.6(oxfmt@0.64.0(svelte@5.56.0))(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))
 
   docs:
@@ -49,22 +104,22 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: ^1.168.14
-        version: 1.168.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))
       fumadocs-core:
         specifier: ^16.9.3
-        version: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
+        version: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.0.10
-        version: 15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       fumadocs-twoslash:
         specifier: ^3.2.0
-        version: 3.2.0(1d030e86b7f7b9132e23a7c3ab6b57d0)
+        version: 3.2.0(b4a625e5e99ec7f2a6e049efc2c17627)
       fumadocs-ui:
         specifier: ^16.9.3
-        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -72,27 +127,27 @@ importers:
         specifier: workspace:*
         version: link:../permix
       react:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
       vite:
-        specifier: ^8.0.16
-        version: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     devDependencies:
       '@orpc/server':
         specifier: ^1.14.4
         version: 1.14.4(crossws@0.4.5(srvx@0.11.16))(fastify@5.8.5)(ws@8.21.0)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@trpc/server':
         specifier: ^11.17.0
-        version: 11.17.0(typescript@6.0.3)
+        version: 11.17.0(typescript@7.0.2)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -100,26 +155,26 @@ importers:
         specifier: ^2.0.13
         version: 2.0.13
       '@types/node':
-        specifier: ^24.10.0
-        version: 24.10.0
+        specifier: 'catalog:'
+        version: 25.9.1
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       drizzle-orm:
         specifier: ^1.0.0-rc.3
         version: 1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(effect@3.21.2)(zod@4.4.3)
       elysia:
         specifier: ^1.4.28
-        version: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1(supports-color@7.2.0))(openapi-types@12.1.3)(typescript@7.0.2)
       express:
         specifier: ^5
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -128,13 +183,13 @@ importers:
         version: 4.12.23
       nitro:
         specifier: ^3.0.260522-beta
-        version: 3.0.260522-beta(chokidar@5.0.0)(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.5.1)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 3.0.260522-beta(chokidar@5.0.0)(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.5.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
 
   examples/enum-based:
     dependencies:
@@ -142,33 +197,33 @@ importers:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   examples/express:
     dependencies:
       express:
         specifier: ^5.2.1
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       permix:
         specifier: workspace:*
         version: link:../../permix
@@ -177,31 +232,34 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       tsx:
-        specifier: ^4.22.4
+        specifier: 'catalog:'
         version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   examples/express-trpc-react:
     dependencies:
       '@trpc/client':
         specifier: ^11.17.0
-        version: 11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)
+        version: 11.17.0(@trpc/server@11.17.0(typescript@7.0.2))(typescript@7.0.2)
       '@trpc/server':
         specifier: ^11.17.0
-        version: 11.17.0(typescript@6.0.3)
+        version: 11.17.0(typescript@7.0.2)
       cors:
         specifier: ^2.8.6
         version: 2.8.6
       express:
         specifier: ^5.1.0
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       permix:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
       zod:
         specifier: ^4.4.3
@@ -217,23 +275,26 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tsx:
-        specifier: ^4.22.4
+        specifier: 'catalog:'
         version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.1.1(supports-color@7.2.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   examples/feature-flags:
     dependencies:
@@ -241,61 +302,61 @@ importers:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   examples/next:
     dependencies:
       next:
         specifier: 16.2.6
-        version: 16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       permix:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: 19.2.4
-        version: 19.2.4
+        specifier: 'catalog:'
+        version: 19.2.6
       react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
       '@types/node':
-        specifier: ^25.9.1
+        specifier: 'catalog:'
         version: 25.9.1
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
 
   examples/react:
     dependencies:
@@ -303,26 +364,26 @@ importers:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   examples/rebac:
@@ -332,14 +393,14 @@ importers:
         version: link:../../permix
     devDependencies:
       '@types/node':
-        specifier: ^25.9.1
+        specifier: 'catalog:'
         version: 25.9.1
       tsx:
-        specifier: ^4.22.4
+        specifier: 'catalog:'
         version: 4.22.4
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
 
   examples/role-based:
     dependencies:
@@ -347,26 +408,26 @@ importers:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   examples/solid:
@@ -379,14 +440,14 @@ importers:
         version: 1.9.13
     devDependencies:
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   examples/svelte:
     dependencies:
@@ -396,34 +457,34 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.61.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/node':
-        specifier: ^25.9.1
+        specifier: 'catalog:'
         version: 25.9.1
       svelte:
         specifier: ^5.55.2
         version: 5.56.0
       svelte-check:
         specifier: ^4.5.0
-        version: 4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@6.0.3)
+        version: 4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@7.0.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   examples/tanstack-start:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.3.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: latest
         version: 0.10.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)
@@ -438,10 +499,10 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.6))(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.168.49(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.49(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.132.0
-        version: 1.168.13(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.13(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       lucide-react:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.6)
@@ -449,10 +510,10 @@ importers:
         specifier: workspace:*
         version: link:../../permix
       react:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
       tailwindcss:
         specifier: ^4.1.18
@@ -463,10 +524,10 @@ importers:
         version: 0.5.19(tailwindcss@4.3.0)
       '@tanstack/devtools-vite':
         specifier: latest
-        version: 0.8.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 0.8.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-cli':
         specifier: ^1.132.0
-        version: 1.167.17
+        version: 1.167.17(supports-color@7.2.0)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -474,29 +535,29 @@ importers:
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/node':
-        specifier: ^22.10.2
-        version: 22.19.20
+        specifier: 'catalog:'
+        version: 25.9.1
       '@types/react':
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/react-dom':
-        specifier: ^19.2.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       jsdom:
         specifier: ^28.1.0
-        version: 28.1.0(@noble/hashes@1.8.0)
+        version: 28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0)
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.0
-        version: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   examples/vue:
     dependencies:
@@ -505,23 +566,23 @@ importers:
         version: link:../../permix
       vue:
         specifier: ^3.5.35
-        version: 3.5.35(typescript@6.0.3)
+        version: 3.5.35(typescript@7.0.2)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@7.0.2))
       '@vue/tsconfig':
         specifier: ^0.9.1
-        version: 0.9.1(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+        version: 0.9.1(typescript@7.0.2)(vue@3.5.35(typescript@7.0.2))
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
       vite:
-        specifier: ^8.0.16
+        specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.3
-        version: 3.3.3(typescript@6.0.3)
+        version: 3.3.3(typescript@7.0.2)
 
   permix:
     dependencies:
@@ -530,13 +591,13 @@ importers:
         version: 1.14.4(crossws@0.4.5(srvx@0.11.16))(fastify@5.8.5)(ws@8.21.0)
       '@trpc/server':
         specifier: '>=11'
-        version: 11.17.0(typescript@6.0.3)
+        version: 11.17.0(typescript@7.0.2)
       elysia:
         specifier: '>=1'
-        version: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1(supports-color@7.2.0))(openapi-types@12.1.3)(typescript@7.0.2)
       express:
         specifier: '>=4'
-        version: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
       fastify:
         specifier: '>=5'
         version: 5.8.5
@@ -548,10 +609,7 @@ importers:
         version: 4.12.23
       next:
         specifier: '>=14'
-        version: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react:
-        specifier: '>=18'
-        version: 19.2.6
+        version: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       solid-js:
         specifier: '>=1'
         version: 1.9.13
@@ -561,7 +619,7 @@ importers:
         version: 0.8.10(solid-js@1.9.13)
       '@sveltejs/package':
         specifier: ^2.5.7
-        version: 2.5.7(svelte@5.56.0)(typescript@6.0.3)
+        version: 2.5.7(svelte@5.56.0)(typescript@7.0.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
         version: 7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -570,7 +628,7 @@ importers:
         version: 0.0.42
       '@tanstack/react-start':
         specifier: ^1.168.18
-        version: 1.168.18(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.18(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -584,23 +642,23 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^25.9.1
+        specifier: 'catalog:'
         version: 25.9.1
       '@types/react':
-        specifier: ^19.2.15
+        specifier: 'catalog:'
         version: 19.2.15
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
       '@vitejs/plugin-react':
-        specifier: ^6.0.2
+        specifier: 'catalog:'
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
       '@vue/test-utils':
         specifier: ^2.4.10
-        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@7.0.2)))(vue@3.5.35(typescript@7.0.2))
       drizzle-orm:
         specifier: 1.0.0-rc.3
         version: 1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(effect@3.21.2)(zod@4.4.3)
@@ -610,33 +668,42 @@ importers:
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
       react-dom:
-        specifier: ^19.2.6
+        specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
       supertest:
         specifier: ^7.2.2
-        version: 7.2.2
+        version: 7.2.2(supports-color@7.2.0)
       svelte:
         specifier: ^5.56.0
         version: 5.56.0
       svelte-check:
         specifier: ^4.5.0
-        version: 4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@6.0.3)
+        version: 4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@7.0.2)
       tsdown:
         specifier: ^0.22.1
-        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)
+        version: 0.22.1(tsx@4.22.4)(typescript@7.0.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: 'catalog:'
+        version: 7.0.2
+      typescript59:
+        specifier: catalog:typescript-classic
+        version: typescript@5.9.3
+      typescript6:
+        specifier: catalog:typescript-classic
+        version: '@typescript/typescript6@6.0.2'
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vue:
         specifier: ^3.5.17
-        version: 3.5.35(typescript@6.0.3)
+        version: 3.5.35(typescript@7.0.2)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3087,33 +3154,33 @@ packages:
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@turbo/darwin-64@2.9.16':
-    resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
+  '@turbo/darwin-64@2.10.12':
+    resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.16':
-    resolution: {integrity: sha512-YPgrn+5HIGzrx0O2a631SV4MBQUe4W/DafMFUuBVgaU32PW9/OTT0ehviF0QSxTXuRJlHvW2eUTemddF5/spmw==}
+  '@turbo/darwin-arm64@2.10.12':
+    resolution: {integrity: sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.16':
-    resolution: {integrity: sha512-vAEf1H6l26lTpl9FJ/peQo1NUB8RC0sbEJJz5mPcUhHA2bPDup2x3CZPgo/bH8S4cUcBLm4FN3UHd5iUO2RAew==}
+  '@turbo/linux-64@2.10.12':
+    resolution: {integrity: sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/linux-arm64@2.9.16':
-    resolution: {integrity: sha512-xDBLR2PZg4BrQOchfG6svgpv5FCNJ2TOtT2psLdEJcdKo1BH+pnPs9Xj6pvUjgfkHbuvBOfeE4R6tvxMoQKDHQ==}
+  '@turbo/linux-arm64@2.10.12':
+    resolution: {integrity: sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/windows-64@2.9.16':
-    resolution: {integrity: sha512-NBAJnaUiGdgkSzQwUIdOvkCkcpTSu58G/sBGa0mvBtzfvFOOgrQwepKOOQ8cp6sWM6OcKDNFj2p1dsZA1OWjPg==}
+  '@turbo/windows-64@2.10.12':
+    resolution: {integrity: sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.16':
-    resolution: {integrity: sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ==}
+  '@turbo/windows-arm64@2.10.12':
+    resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3288,12 +3355,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@22.19.20':
-    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
-
-  '@types/node@24.10.0':
-    resolution: {integrity: sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==}
-
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
@@ -3340,6 +3401,130 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -3447,6 +3632,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/compiler-core@3.5.35':
     resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
@@ -5194,9 +5384,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.3:
-    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
-
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
@@ -5854,11 +6041,6 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
-    peerDependencies:
-      react: ^19.2.4
-
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -5896,10 +6078,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -6457,8 +6635,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.16:
-    resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
+  turbo@2.10.12:
+    resolution: {integrity: sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==}
     hasBin: true
 
   twoslash-protocol@0.3.8:
@@ -6477,9 +6655,19 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   ufo@1.6.4:
@@ -6506,12 +6694,6 @@ packages:
 
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
-
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -6948,7 +7130,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.2.3
+      tinyexec: 1.3.0
 
   '@antfu/ni@30.1.0':
     dependencies:
@@ -6991,20 +7173,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7042,19 +7224,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7083,14 +7265,14 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.6
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -7101,7 +7283,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -7109,7 +7291,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7449,7 +7631,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/mdx@3.1.1':
+  '@mdx-js/mdx@3.1.1(supports-color@7.2.0)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -7461,14 +7643,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@7.2.0)
+      remark-mdx: 3.1.1(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -8312,12 +8494,12 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.1.0
 
-  '@shikijs/twoslash@4.1.0(typescript@6.0.3)':
+  '@shikijs/twoslash@4.1.0(supports-color@7.2.0)(typescript@7.0.2)':
     dependencies:
       '@shikijs/core': 4.1.0
       '@shikijs/types': 4.1.0
-      twoslash: 0.3.8(typescript@6.0.3)
-      typescript: 6.0.3
+      twoslash: 0.3.8(supports-color@7.2.0)(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8377,32 +8559,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@types/cookie': 0.6.0
-      acorn: 8.16.0
-      cookie: 0.6.0
-      devalue: 5.8.1
-      esm-env: 1.2.2
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      set-cookie-parser: 3.1.0
-      sirv: 3.0.2
-      svelte: 5.56.0
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-    optionalDependencies:
-      typescript: 6.0.3
-    optional: true
-
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
@@ -8420,28 +8581,18 @@ snapshots:
       svelte: 5.56.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  '@sveltejs/package@2.5.7(svelte@5.56.0)(typescript@6.0.3)':
+  '@sveltejs/package@2.5.7(svelte@5.56.0)(typescript@7.0.2)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.8.1
       svelte: 5.56.0
-      svelte2tsx: 0.7.55(svelte@5.56.0)(typescript@6.0.3)
+      svelte2tsx: 0.7.55(svelte@5.56.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - typescript
-
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      deepmerge: 4.3.1
-      magic-string: 0.30.21
-      obug: 2.1.1
-      svelte: 5.56.0
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-    optional: true
 
   '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -8530,19 +8681,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@tailwindcss/node': 4.3.0
-      '@tailwindcss/oxide': 4.3.0
-      tailwindcss: 4.3.0
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tanstack/devtools-bundler-core@0.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -8581,13 +8725,13 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.8.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/devtools-vite@0.8.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/devtools-bundler-core': 0.1.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@tanstack/devtools-client': 0.0.8
       '@tanstack/devtools-event-bus': 0.4.3
       chalk: 5.6.2
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8727,15 +8871,15 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@tanstack/react-start-rsc@0.1.17(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.17(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-server': 1.167.13(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.8
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.6
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.8(crossws@0.4.5(srvx@0.11.16))
       '@tanstack/start-storage-context': 1.167.10
       pathe: 2.0.3
@@ -8749,14 +8893,14 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-rsc@0.1.23(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.23(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.13
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.11
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.13(crossws@0.4.5(srvx@0.11.16))
       '@tanstack/start-storage-context': 1.167.15
       pathe: 2.0.3
@@ -8770,14 +8914,14 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start-rsc@0.1.48(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.48(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.27
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.27
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-storage-context': 1.167.29
       pathe: 2.0.3
       react: 19.2.6
@@ -8822,15 +8966,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.18(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.18(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.168.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.1.17(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.17(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.13(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.6
-      '@tanstack/start-plugin-core': 1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.8(crossws@0.4.5(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.6
@@ -8845,21 +8989,21 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start@1.168.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.168.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.1.23(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.23(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.18(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.11
-      '@tanstack/start-plugin-core': 1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.13(crossws@0.4.5(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -8868,21 +9012,21 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/react-start@1.168.49(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.49(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.168.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.1.48(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.48(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.37(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.27
-      '@tanstack/start-plugin-core': 1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.31(crossws@0.4.5(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -8898,9 +9042,9 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
 
-  '@tanstack/router-cli@1.167.17':
+  '@tanstack/router-cli@1.167.17(supports-color@7.2.0)':
     dependencies:
-      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-generator': 1.167.17(supports-color@7.2.0)
       chokidar: 5.0.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -8943,11 +9087,11 @@ snapshots:
     optionalDependencies:
       csstype: 3.2.3
 
-  '@tanstack/router-generator@1.167.12':
+  '@tanstack/router-generator@1.167.12(supports-color@7.2.0)':
     dependencies:
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.8
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -8956,11 +9100,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-generator@1.167.17':
+  '@tanstack/router-generator@1.167.17(supports-color@7.2.0)':
     dependencies:
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.13
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -8969,11 +9113,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-generator@1.167.33':
+  '@tanstack/router-generator@1.167.33(supports-color@7.2.0)':
     dependencies:
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.27
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -8982,17 +9126,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.13(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.13(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.8
-      '@tanstack/router-generator': 1.167.12
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-generator': 1.167.12(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/virtual-file-routes': 1.162.0
       chokidar: 5.0.0
       unplugin: 3.0.0
@@ -9000,65 +9144,65 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.13(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.13(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.8
-      '@tanstack/router-generator': 1.167.12
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-generator': 1.167.12(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/virtual-file-routes': 1.162.0
       chokidar: 5.0.0
       unplugin: 3.0.0
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-generator': 1.167.17(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       chokidar: 5.0.0
       unplugin: 3.0.0
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.35(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.35(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.27
-      '@tanstack/router-generator': 1.167.33
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-generator': 1.167.33(supports-color@7.2.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       chokidar: 5.0.0
       unplugin: 3.0.0
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9067,27 +9211,27 @@ snapshots:
       '@tanstack/query-core': 5.101.0
       '@tanstack/router-core': 1.171.27
 
-  '@tanstack/router-utils@1.162.1':
+  '@tanstack/router-utils@1.162.1(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       ansis: 4.3.0
-      babel-dead-code-elimination: 1.0.12
+      babel-dead-code-elimination: 1.0.12(supports-color@7.2.0)
       diff: 8.0.4
       pathe: 2.0.3
       tinyglobby: 0.2.17
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-utils@1.162.2':
+  '@tanstack/router-utils@1.162.2(supports-color@7.2.0)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       ansis: 4.3.0
-      babel-dead-code-elimination: 1.0.12
+      babel-dead-code-elimination: 1.0.12(supports-color@7.2.0)
       diff: 8.0.4
       pathe: 2.0.3
       tinyglobby: 0.2.17
@@ -9117,18 +9261,49 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.10(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@rolldown/pluginutils': 1.0.1
       '@tanstack/router-core': 1.171.8
-      '@tanstack/router-generator': 1.167.12
-      '@tanstack/router-plugin': 1.168.13(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@tanstack/router-utils': 1.162.1
+      '@tanstack/router-generator': 1.167.12(supports-color@7.2.0)
+      '@tanstack/router-plugin': 1.168.13(@tanstack/react-router@1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/router-utils': 1.162.1(supports-color@7.2.0)
       '@tanstack/start-client-core': 1.170.6
       '@tanstack/start-server-core': 1.169.8(crossws@0.4.5(srvx@0.11.16))
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      seroval: 1.5.4
+      source-map: 0.7.6
+      srvx: 0.11.16
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/start-plugin-core@1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17(supports-color@7.2.0)
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
+      '@tanstack/start-server-core': 1.169.13(crossws@0.4.5(srvx@0.11.16))
       exsolve: 1.0.8
       lightningcss: 1.32.0
       pathe: 2.0.3
@@ -9150,61 +9325,30 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-plugin-core@1.171.16(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-server-core': 1.169.13(crossws@0.4.5(srvx@0.11.16))
-      exsolve: 1.0.8
-      lightningcss: 1.32.0
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.4
-      source-map: 0.7.6
-      srvx: 0.11.16
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      xmlbuilder2: 4.0.3
-      zod: 4.4.3
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@tanstack/react-router'
-      - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
-
-  '@tanstack/start-plugin-core@1.171.39(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.16))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.27
-      '@tanstack/router-generator': 1.167.33
-      '@tanstack/router-plugin': 1.168.35(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-generator': 1.167.33(supports-color@7.2.0)
+      '@tanstack/router-plugin': 1.168.35(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/router-utils': 1.162.2(supports-color@7.2.0)
       '@tanstack/start-server-core': 1.169.31(crossws@0.4.5(srvx@0.11.16))
       exsolve: 1.0.8
       lightningcss: 1.32.0
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       seroval: 1.6.4
       source-map: 0.7.6
       srvx: 0.11.16
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
       - crossws
@@ -9305,42 +9449,42 @@ snapshots:
       svelte: 5.56.0
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
 
-  '@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@6.0.3))(typescript@6.0.3)':
+  '@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@7.0.2))(typescript@7.0.2)':
     dependencies:
-      '@trpc/server': 11.17.0(typescript@6.0.3)
-      typescript: 6.0.3
+      '@trpc/server': 11.17.0(typescript@7.0.2)
+      typescript: 7.0.2
 
-  '@trpc/server@11.17.0(typescript@6.0.3)':
+  '@trpc/server@11.17.0(typescript@7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  '@turbo/darwin-64@2.9.16':
+  '@turbo/darwin-64@2.10.12':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.16':
+  '@turbo/darwin-arm64@2.10.12':
     optional: true
 
-  '@turbo/linux-64@2.9.16':
+  '@turbo/linux-64@2.10.12':
     optional: true
 
-  '@turbo/linux-arm64@2.9.16':
+  '@turbo/linux-arm64@2.10.12':
     optional: true
 
-  '@turbo/windows-64@2.9.16':
+  '@turbo/windows-64@2.10.12':
     optional: true
 
-  '@turbo/windows-arm64@2.9.16':
+  '@turbo/windows-arm64@2.10.12':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -9555,14 +9699,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@22.19.20':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@24.10.0':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -9618,10 +9754,74 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
     dependencies:
-      debug: 4.4.3
-      typescript: 6.0.3
+      '@typescript/old': typescript@6.0.3
+
+  '@typescript/vfs@1.6.4(supports-color@7.2.0)(typescript@7.0.2)':
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9632,34 +9832,24 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))':
     optionalDependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      next: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       svelte: 5.56.0
-      vue: 3.5.35(typescript@6.0.3)
-
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vue: 3.5.35(typescript@7.0.2)
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.35(typescript@7.0.2)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -9669,11 +9859,11 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.3
+      magicast: 0.5.4
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -9683,14 +9873,6 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -9730,11 +9912,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   '@vue/compiler-core@3.5.35':
     dependencies:
@@ -9774,7 +9958,7 @@ snapshots:
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.7
 
   '@vue/reactivity@3.5.35':
     dependencies:
@@ -9792,27 +9976,27 @@ snapshots:
       '@vue/shared': 3.5.35
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3))':
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@7.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.35
       '@vue/shared': 3.5.35
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.35(typescript@7.0.2)
 
   '@vue/shared@3.5.35': {}
 
-  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@7.0.2)))(vue@3.5.35(typescript@7.0.2))':
     dependencies:
       '@vue/compiler-dom': 3.5.35
       js-beautify: 1.15.4
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.35(typescript@7.0.2)
       vue-component-type-helpers: 3.3.3
     optionalDependencies:
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@7.0.2))
 
-  '@vue/tsconfig@0.9.1(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))':
+  '@vue/tsconfig@0.9.1(typescript@7.0.2)(vue@3.5.35(typescript@7.0.2))':
     optionalDependencies:
-      typescript: 6.0.3
-      vue: 3.5.35(typescript@6.0.3)
+      typescript: 7.0.2
+      vue: 3.5.35(typescript@7.0.2)
 
   abbrev@2.0.0: {}
 
@@ -9905,28 +10089,28 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-dead-code-elimination@1.0.12:
+  babel-dead-code-elimination@1.0.12(supports-color@7.2.0):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/parser': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
+  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7(supports-color@7.2.0)):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
       '@babel/types': 7.29.7
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.7)(solid-js@1.9.13):
+  babel-preset-solid@1.9.12(@babel/core@7.29.7(supports-color@7.2.0))(solid-js@1.9.13):
     dependencies:
-      '@babel/core': 7.29.7
-      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.7(supports-color@7.2.0))
     optionalDependencies:
       solid-js: 1.9.13
 
@@ -9942,11 +10126,11 @@ snapshots:
 
   birpc@4.0.0: {}
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@7.2.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -10330,9 +10514,11 @@ snapshots:
     optionalDependencies:
       drizzle-orm: 1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(effect@3.21.2)(zod@4.4.3)
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
 
@@ -10416,17 +10602,17 @@ snapshots:
 
   electron-to-chromium@1.5.364: {}
 
-  elysia@1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1)(openapi-types@12.1.3)(typescript@6.0.3):
+  elysia@1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@1.0.0)(file-type@22.0.1(supports-color@7.2.0))(openapi-types@12.1.3)(typescript@7.0.2):
     dependencies:
       '@sinclair/typebox': 0.34.49
       cookie: 1.1.1
       exact-mirror: 1.0.0
       fast-decode-uri-component: 1.0.1
-      file-type: 22.0.1
+      file-type: 22.0.1(supports-color@7.2.0)
       memoirist: 0.4.0
       openapi-types: 12.1.3
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   emoji-regex@8.0.0: {}
 
@@ -10590,20 +10776,20 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@7.2.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@7.2.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10614,9 +10800,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
+      serve-static: 2.2.1(supports-color@7.2.0)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -10708,9 +10894,9 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
-  file-type@22.0.1:
+  file-type@22.0.1(supports-color@7.2.0):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -10721,9 +10907,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -10779,18 +10965,18 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3):
+  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
-      hast-util-to-estree: 3.1.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-estree: 3.1.3(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
       js-yaml: 4.1.1
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
-      remark: 15.0.1
-      remark-gfm: 4.0.1
+      remark: 15.0.1(supports-color@7.2.0)
+      remark-gfm: 4.0.1(supports-color@7.2.0)
       remark-rehype: 11.1.2
       scroll-into-view-if-needed: 3.1.0
       shiki: 4.1.0
@@ -10799,30 +10985,30 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     optionalDependencies:
-      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
       '@tanstack/react-router': 1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.15
       lucide-react: 1.17.0(react@19.2.6)
-      next: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  fumadocs-mdx@15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       js-yaml: 4.1.1
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@7.2.0)
       picocolors: 1.1.1
       picomatch: 4.0.4
       tinyexec: 1.2.3
@@ -10836,27 +11022,27 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.15
-      next: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       rolldown: 1.0.3
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.2.0(1d030e86b7f7b9132e23a7c3ab6b57d0):
+  fumadocs-twoslash@3.2.0(b4a625e5e99ec7f2a6e049efc2c17627):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@shikijs/twoslash': 4.1.0(typescript@6.0.3)
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
-      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-gfm: 3.1.0
+      '@shikijs/twoslash': 4.1.0(supports-color@7.2.0)(typescript@7.0.2)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
+      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       mdast-util-to-hast: 13.2.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       shiki: 4.1.0
       tailwind-merge: 3.6.0
-      twoslash: 0.3.8(typescript@6.0.3)
+      twoslash: 0.3.8(supports-color@7.2.0)(typescript@7.0.2)
     optionalDependencies:
       '@types/react': 19.2.15
     transitivePeerDependencies:
@@ -10864,7 +11050,7 @@ snapshots:
       - supports-color
       - typescript
 
-  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
+  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.0)(tailwindcss@4.3.0)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -10878,7 +11064,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.15)(react@19.2.6)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       lucide-react: 1.17.0(react@19.2.6)
       motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -10893,7 +11079,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.15
-      next: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@tailwindcss/oxide'
@@ -11035,7 +11221,7 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@7.2.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -11045,9 +11231,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -11070,7 +11256,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -11079,9 +11265,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -11136,17 +11322,17 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11272,7 +11458,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@28.1.0(@noble/hashes@1.8.0):
+  jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -11282,8 +11468,8 @@ snapshots:
       data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.1
       saxes: 6.0.0
@@ -11422,12 +11608,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.3:
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      source-map-js: 1.2.1
-
   magicast@0.5.4:
     dependencies:
       '@babel/parser': 7.29.7
@@ -11453,14 +11633,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -11478,67 +11658,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@7.2.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -11546,7 +11726,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -11555,23 +11735,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@7.2.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11893,10 +12073,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -11982,7 +12162,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -11991,7 +12171,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -12005,59 +12185,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  next@16.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@next/env': 16.2.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.33
-      caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      '@next/env': 16.2.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.33
-      caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
 
   nf3@0.3.17: {}
 
-  nitro@3.0.260522-beta(chokidar@5.0.0)(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.5.1)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  nitro@3.0.260522-beta(chokidar@5.0.0)(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3))(jiti@2.7.0)(lru-cache@11.5.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.16)
@@ -12075,7 +12206,7 @@ snapshots:
       unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3)))(lru-cache@11.5.1)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       jiti: 2.7.0
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12447,11 +12578,6 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@19.2.4(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      scheduler: 0.27.0
-
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -12485,8 +12611,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.15
-
-  react@19.2.4: {}
 
   react@19.2.6: {}
 
@@ -12553,36 +12677,36 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@7.2.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@7.2.0):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@7.2.0)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -12602,10 +12726,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1:
+  remark@15.0.1(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -12632,7 +12756,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.25.2(rolldown@1.0.3)(typescript@6.0.3):
+  rolldown-plugin-dts@0.25.2(rolldown@1.0.3)(typescript@7.0.2):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
@@ -12644,7 +12768,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.3
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -12678,9 +12802,9 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
-  router@2.2.0:
+  router@2.2.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -12724,9 +12848,9 @@ snapshots:
 
   semver@7.8.1: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -12752,12 +12876,12 @@ snapshots:
 
   seroval@1.6.4: {}
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@7.2.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12869,10 +12993,10 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-refresh@0.6.3(solid-js@1.9.13):
+  solid-refresh@0.6.3(solid-js@1.9.13)(supports-color@7.2.0):
     dependencies:
       '@babel/generator': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       solid-js: 1.9.13
     transitivePeerDependencies:
@@ -12946,25 +13070,20 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
     optionalDependencies:
-      '@babel/core': 7.29.7
-
-  styled-jsx@5.1.6(react@19.2.4):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.4
+      '@babel/core': 7.29.7(supports-color@7.2.0)
 
   stylis@4.4.0: {}
 
-  superagent@10.3.0:
+  superagent@10.3.0(supports-color@7.2.0):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -12974,11 +13093,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.2.2:
+  supertest@7.2.2(supports-color@7.2.0):
     dependencies:
       cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 10.3.0
+      superagent: 10.3.0(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12986,7 +13105,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-check@4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@6.0.3):
+  svelte-check@4.5.0(picomatch@4.0.7)(svelte@5.56.0)(typescript@7.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
@@ -12994,16 +13113,16 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte2tsx@0.7.55(svelte@5.56.0)(typescript@6.0.3):
+  svelte2tsx@0.7.55(svelte@5.56.0)(typescript@7.0.2):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
       svelte: 5.56.0
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   svelte@5.56.0:
     dependencies:
@@ -13108,11 +13227,11 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.3):
+  tsconfck@3.1.6(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  tsdown@0.22.1(tsx@4.22.4)(typescript@6.0.3):
+  tsdown@0.22.1(tsx@4.22.4)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.0
       cac: 7.0.0
@@ -13123,7 +13242,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.3
-      rolldown-plugin-dts: 0.25.2(rolldown@1.0.3)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.25.2(rolldown@1.0.3)(typescript@7.0.2)
       semver: 7.8.1
       tinyexec: 1.2.3
       tinyglobby: 0.2.17
@@ -13131,7 +13250,7 @@ snapshots:
       unconfig-core: 7.5.0
     optionalDependencies:
       tsx: 4.22.4
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -13146,22 +13265,22 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.16:
+  turbo@2.10.12:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.16
-      '@turbo/darwin-arm64': 2.9.16
-      '@turbo/linux-64': 2.9.16
-      '@turbo/linux-arm64': 2.9.16
-      '@turbo/windows-64': 2.9.16
-      '@turbo/windows-arm64': 2.9.16
+      '@turbo/darwin-64': 2.10.12
+      '@turbo/darwin-arm64': 2.10.12
+      '@turbo/linux-64': 2.10.12
+      '@turbo/linux-arm64': 2.10.12
+      '@turbo/windows-64': 2.10.12
+      '@turbo/windows-arm64': 2.10.12
 
   twoslash-protocol@0.3.8: {}
 
-  twoslash@0.3.8(typescript@6.0.3):
+  twoslash@0.3.8(supports-color@7.2.0)(typescript@7.0.2):
     dependencies:
-      '@typescript/vfs': 1.6.4(typescript@6.0.3)
+      '@typescript/vfs': 1.6.4(supports-color@7.2.0)(typescript@7.0.2)
       twoslash-protocol: 0.3.8
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13175,7 +13294,32 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.4: {}
 
@@ -13215,10 +13359,6 @@ snapshots:
       jiti: 2.7.0
       quansync: 1.0.0
       unconfig-core: 7.5.0
-
-  undici-types@6.21.0: {}
-
-  undici-types@7.16.0: {}
 
   undici-types@7.24.6: {}
 
@@ -13277,7 +13417,7 @@ snapshots:
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       webpack-virtual-modules: 0.6.2
 
   unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@1.0.0-rc.3(@sinclair/typebox@0.34.49)(@types/pg@8.20.0)(zod@4.4.3)))(lru-cache@11.5.1)(ofetch@2.0.0-alpha.3):
@@ -13333,46 +13473,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7(supports-color@7.2.0))(solid-js@1.9.13)
       merge-anything: 5.1.7
       solid-js: 1.9.13
-      solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-    optionalDependencies:
-      '@testing-library/jest-dom': 6.9.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
-      merge-anything: 5.1.7
-      solid-js: 1.9.13
-      solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-    optionalDependencies:
-      '@testing-library/jest-dom': 6.9.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
-      merge-anything: 5.1.7
-      solid-js: 1.9.13
-      solid-refresh: 0.6.3(solid-js@1.9.13)
+      solid-refresh: 0.6.3(solid-js@1.9.13)(supports-color@7.2.0)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
@@ -13380,50 +13488,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.1.1(supports-color@7.2.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(typescript@7.0.2)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.19.20
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.22.4
-      yaml: 2.9.0
-
-  vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.10.0
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.22.4
-      yaml: 2.9.0
-
   vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       postcss: 8.5.15
       rolldown: 1.0.3
       tinyglobby: 0.2.17
@@ -13435,49 +13513,11 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-
-  vitefu@1.1.3(vite@8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 8.0.16(@types/node@24.10.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-
   vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@22.19.20)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.3
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.20
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      happy-dom: 20.9.0
-      jsdom: 28.1.0(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -13491,10 +13531,10 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.3
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -13503,7 +13543,7 @@ snapshots:
       '@types/node': 25.9.1
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       happy-dom: 20.9.0
-      jsdom: 28.1.0(@noble/hashes@1.8.0)
+      jsdom: 28.1.0(@noble/hashes@1.8.0)(supports-color@7.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -13511,21 +13551,21 @@ snapshots:
 
   vue-component-type-helpers@3.3.3: {}
 
-  vue-tsc@3.3.3(typescript@6.0.3):
+  vue-tsc@3.3.3(typescript@7.0.2):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@7.0.2)
       '@vue/language-core': 3.3.3
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  vue@3.5.35(typescript@6.0.3):
+  vue@3.5.35(typescript@7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.35
       '@vue/compiler-sfc': 3.5.35
       '@vue/runtime-dom': 3.5.35
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@7.0.2))
       '@vue/shared': 3.5.35
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,19 +107,19 @@ importers:
         version: 1.168.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))
+        version: 2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))
       fumadocs-core:
         specifier: ^16.9.3
-        version: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
+        version: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.0.10
-        version: 15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       fumadocs-twoslash:
         specifier: ^3.2.0
-        version: 3.2.0(b4a625e5e99ec7f2a6e049efc2c17627)
+        version: 3.2.0(056b6d17c4e5ae10ed9baa01b99cdd99)
       fumadocs-ui:
         specifier: ^16.9.3
-        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+        version: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -327,8 +327,8 @@ importers:
   examples/next:
     dependencies:
       next:
-        specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 16.3.3
+        version: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       permix:
         specifier: workspace:*
         version: link:../../permix
@@ -496,7 +496,7 @@ importers:
         version: 1.167.1(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-router-ssr-query':
         specifier: latest
-        version: 1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.6))(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.167.2(@tanstack/query-core@5.102.7)(@tanstack/react-query@5.102.7(react@19.2.6))(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: latest
         version: 1.168.49(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(vite-plugin-solid@2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.13)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -608,8 +608,8 @@ importers:
         specifier: '>=4'
         version: 4.12.23
       next:
-        specifier: '>=14'
-        version: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: '>=15'
+        version: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       solid-js:
         specifier: '>=1'
         version: 1.9.13
@@ -707,6 +707,49 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+
+  permix/test/next:
+    dependencies:
+      permix:
+        specifier: workspace:*
+        version: link:../..
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@next/playwright':
+        specifier: 16.3.3
+        version: 16.3.3(@playwright/test@1.62.1)
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.62.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      next-15:
+        specifier: npm:next@15.5.24
+        version: next@15.5.24(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next-16-0:
+        specifier: npm:next@16.0.11
+        version: next@16.0.11(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next-16-3:
+        specifier: npm:next@16.3.3
+        version: next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      typescript59:
+        specifier: catalog:typescript-classic
+        version: typescript@5.9.3
 
 packages:
 
@@ -924,6 +967,9 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -1156,14 +1202,36 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    resolution: {integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.35.4':
+    resolution: {integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    resolution: {integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
+    resolution: {integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1172,8 +1240,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    resolution: {integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
+    resolution: {integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1184,8 +1263,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    resolution: {integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
+    resolution: {integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1196,8 +1287,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    resolution: {integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
+    resolution: {integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1208,14 +1311,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    resolution: {integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    resolution: {integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
+    resolution: {integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1227,9 +1348,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.4':
+    resolution: {integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.4':
+    resolution: {integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -1241,9 +1376,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.4':
+    resolution: {integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    resolution: {integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1255,9 +1404,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.4':
+    resolution: {integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.4':
+    resolution: {integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1269,9 +1432,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    resolution: {integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    resolution: {integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1281,9 +1458,24 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.35.4':
+    resolution: {integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    resolution: {integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.4':
+    resolution: {integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -1293,9 +1485,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.4':
+    resolution: {integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.4':
+    resolution: {integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -1340,13 +1544,60 @@ packages:
       '@neodrag/core': 3.0.0-next.11
       solid-js: ^1.0.0
 
+  '@next/env@15.5.24':
+    resolution: {integrity: sha512-mBDF7T0XKZjs9SpUAl0buizVO+O02ULjOvWX8o/AZo/5AGw/UAS1Zzcylmd4pqbftzmKQi+L/nB4jgBYKEAl5Q==}
+
+  '@next/env@16.0.11':
+    resolution: {integrity: sha512-hULMheQaOhFK1vAoFPigXca42LguwyLILtJKPRzpY1d+og6jk0YNAQVwLGNYYhWEMd2zj4gcIWSf1yC5PffqqA==}
+
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+
+  '@next/env@16.3.3':
+    resolution: {integrity: sha512-U2eYQRwXj+dsqxV79zFqExDdatnNY/ZWc2nsJU1p/OgT7fd3dXwlF6OjYaFQCfMoeTA19PWq+wVmYgimVA+V+g==}
+
+  '@next/playwright@16.3.3':
+    resolution: {integrity: sha512-Uha5vKciXER99u9J9ePBW6FQJxMklZp9K2r+xzW/KBvaS2ITvOsP/6BMyQBv2FJbitW5TQv+KNv72aqtnsikuw==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+
+  '@next/swc-darwin-arm64@15.5.24':
+    resolution: {integrity: sha512-AGdNLvxZNY6eR2iSnV+6wUa8CiHTMr4F7g3uHH7fT4ICIJBE00R9u4tzN/Vuwsw0cOi8MTD2HJcTCb6siMH88Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.0.11':
+    resolution: {integrity: sha512-3G7Rx6m6tgLqkc3Ce3QY/Yrsx7nJF4ithdHfx70Jmzel8m2xpjnGRC+oB4UcCHvQwN0ZP5YsLJakwx/M0vWbSQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
 
   '@next/swc-darwin-arm64@16.2.6':
     resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.3.3':
+    resolution: {integrity: sha512-8Hiv32QJPwdV6KYJ8meR9SBA061tQqnIKTJDocvOXlEQqib0xMFpzArosuffFUUc0sslbh7QQ8a3Yey1QV8EIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.24':
+    resolution: {integrity: sha512-9HrQajBMmGcrrrvDfRimiCrbAPh3E6uHJmwBovYr6Yrmi9p9PZqI876BrXX280wICh3o2XwUlp4blkB0NNBqFg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.0.11':
+    resolution: {integrity: sha512-poUTsYKRwuG+eApDngouEiN6AGcAMq8TAQYP8Nou7iMS7x6+q3dFhhyhgodIzTF9acsEINl4cIzMaM9XJor8kw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@next/swc-darwin-x64@16.2.6':
@@ -1355,12 +1606,53 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.3.3':
+    resolution: {integrity: sha512-A1lgKgwVchRYmSe467zdwhxT9040dd8lH+o65sL5Jet8fjB4kegw/rDyPIpYVRb6jAqwXFOJpjIXJLxQKLiE3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.24':
+    resolution: {integrity: sha512-rl9LSfE75si0WT3cDgdUC1XYCKS+TgxC+/IjitmeycrAG18X/plIP1/vy8dd/HPycYcIvE688PD7FuvEAiEAew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.0.11':
+    resolution: {integrity: sha512-Q9shvB+eLNrK/n8w+/ZTWSzbEIzJ56mP83ZVaqmHay6/Ulcn6THEId4gxfYCXmSwEG/xPAtv58FBWeZkp36XUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@next/swc-linux-arm64-gnu@16.2.6':
     resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.3.3':
+    resolution: {integrity: sha512-bf0FIssMFueU2dm7vQEWWxk0c8UjKTdW0yzuh0sQsD8pf1+KCLDdaqhYZNMYGmXwEOiHAUzgBKudovIlcvvBjg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.24':
+    resolution: {integrity: sha512-TlNAnpsjxSF3aAUtqnfmtXXf8m9sIDBlmF3c7bTAlnshUYu2U0OxN2uf5d0gcFwqHVEdivJNBcCaqNOwPGNimw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-arm64-musl@16.0.11':
+    resolution: {integrity: sha512-rq+d/a0FZHVPEh3zismoQgfVkSIEzlTbNhD4Z8bToLMszUlggAh1D1syhJ4MHkYzXRszhjS2emy0PYXz7Uwttw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
@@ -1369,12 +1661,54 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.3.3':
+    resolution: {integrity: sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.24':
+    resolution: {integrity: sha512-7dwtlhr0SLndqTG1z9ncRkbJswDZiKWlxzFyXDvJ2RDZRDRHp8zyMJ4D9UH/FgnQeXxxB6gZy2pMcIUoNKQ4pA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.0.11':
+    resolution: {integrity: sha512-82Wroterii1p15O+ZF/DDsHPuxKptR1JGK+obgbAk13vrc3B/fTJ2qOOmdeoMwAQ15gb/9mN4LQl9+IzFje76Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.3.3':
+    resolution: {integrity: sha512-0W46zw1N3ODpI6n0GeivHvvob1pooozgZVqy65k0mh4/7vr+FbY9+WpHzNVXjHipJf/A3FDheBG19H1s5A25rA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.24':
+    resolution: {integrity: sha512-kGZxM+WhkYs0276lFrMkj7PRtXT3Btp6cwvfSO/cCVLxJJttB5Ccnl2niaCgUja8HgSbEVnMHpg3FJWoOJ9e/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-musl@16.0.11':
+    resolution: {integrity: sha512-YK9RoeZuHWBd+wHi5/7VLp6P5ZOldAjQfBjjtzcR4f14FNmwT0a3ozMMlG2txDxh53krAd5yOO601RbJxH0gCQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
@@ -1383,14 +1717,57 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.3.3':
+    resolution: {integrity: sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.24':
+    resolution: {integrity: sha512-jBDDkZ/qKAqkWivWDMkJSXUzbzV0QKRBKJjEHUAvSB97Hzw7NLzJ6yV56Lts/wjir7s4P31GYgpbS6ZL+hasAA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@16.0.11':
+    resolution: {integrity: sha512-pcDMpSckekV8xj2SSKO8PaqaJhrmDx84zUNip0kOWsT/ERhhDpnWkr6KXMqRXVp2y5CW9pp4LwOFdtpt3rhRgw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.3.3':
+    resolution: {integrity: sha512-cTMUJpcEGmeywofCUfhR+rSsoE33+rVPnPEYNTNdLNlsOeEg/vktOsKUSTb28vUGqD2jkm4Zaskcwn7OCI6FQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.24':
+    resolution: {integrity: sha512-JqtwjvvorjacQ0spgjmUJoxySoYgPwdT1sFdQ0/zmW4iMlP2hjYlCoJIyS7o6Epb4Fug8eco3HXFoBDUCDeH7Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.0.11':
+    resolution: {integrity: sha512-Zzo9NLLRzBSHw9zOGpER/gdc5rofZHLjR2OIUIfoBaN2Oo5zWRl43IF5rMSX2LX7MPLTx4Ww8+5lNHAhXgitnA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@16.2.6':
     resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.3.3':
+    resolution: {integrity: sha512-2VR4cTBzHXaBjnGsuH6GyJjENzQOmHeAh11uY1iUhjm3j5dEUrVJuUj+VL78jaGi/Dik8xS76zEj18BsFhlVZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1901,6 +2278,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2509,6 +2891,9 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -2660,8 +3045,8 @@ packages:
     resolution: {integrity: sha512-jRjArJ8wcMmi49tByK6KCrJxPp8EqFuFH+ltDG6HTPizTrBCAXkJB3dTtTXurLJh67YsPLzU0wLPdOtWYDuGSw==}
     hasBin: true
 
-  '@tanstack/query-core@5.101.0':
-    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+  '@tanstack/query-core@5.102.7':
+    resolution: {integrity: sha512-4TH8KQrCLoNs9Zvl1LW1iaZ9cZx3dGTgfZ1BnLrcRxMNnX/toe/dGbfvF/DkvbzRyfLfpMKZkembz3o0rnugtw==}
 
   '@tanstack/react-devtools@0.10.12':
     resolution: {integrity: sha512-dgoz7TFm97Izo/D34z91PD0h+ufk+eBmoN9OgRHJlj/c7Ol5xpIP7bqLBNByjgt5paRE2eSu5AQHV92Ul+G6iw==}
@@ -2672,8 +3057,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-query@5.101.0':
-    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+  '@tanstack/react-query@5.102.7':
+    resolution: {integrity: sha512-bbd8T4jDIj9aPbNn11SsjNH8apKY4zspkrw63JRsNDXjpW5SRF7X0ipi7yrGd8DCs8QhYfhQJKqEj1YLru1DbQ==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -2701,12 +3086,12 @@ packages:
       '@tanstack/router-core':
         optional: true
 
-  '@tanstack/react-router-ssr-query@1.167.1':
-    resolution: {integrity: sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==}
+  '@tanstack/react-router-ssr-query@1.167.2':
+    resolution: {integrity: sha512-yRvy0VJ00R8huPuquk+qyYQGMpYRc/G33mc6/yZ4f7LaBZz9h/VbACjmLzhm/+6u5WSmUt6ouJJZnI1/5Npfag==}
     engines: {node: '>=20.19'}
     peerDependencies:
-      '@tanstack/query-core': '>=5.90.0'
-      '@tanstack/react-query': '>=5.90.0'
+      '@tanstack/query-core': '>=5.102.0'
+      '@tanstack/react-query': '>=5.102.0'
       '@tanstack/react-router': '>=1.127.0'
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
@@ -2994,11 +3379,11 @@ packages:
       webpack:
         optional: true
 
-  '@tanstack/router-ssr-query-core@1.169.1':
-    resolution: {integrity: sha512-rngux8s/3mPQzcjLYDLkNU31coYVyCgrVTfpdwqUdY5jIEHqGTXrO73DTkPR1PppwYUeVhmNCgl8TctRcnupjg==}
+  '@tanstack/router-ssr-query-core@1.169.2':
+    resolution: {integrity: sha512-7pO65Aiq/1+aS3Mb6vSGtIjzQ/YGv9JTfBbn2EYlHcZnJ4s4ZGCeTPI847geB1RfJqVhfwxM8bZgGM51mYkolg==}
     engines: {node: '>=20.19'}
     peerDependencies:
-      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/query-core': '>=5.102.0'
       '@tanstack/router-core': '>=1.127.0'
 
   '@tanstack/router-utils@1.162.1':
@@ -4757,6 +5142,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5676,6 +6066,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -5686,8 +6081,71 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
+  next@15.5.24:
+    resolution: {integrity: sha512-Y+xn8EQCoC3ZbsFPyzE+tE8XOdrWeUdUF7NeXbmg9DsgAxl5UYxlsrvgVESHTyTGigoTa1bCUrxn70F5bqt0Gw==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.0.11:
+    resolution: {integrity: sha512-Xlo2aFWaoypPzXr4PFLSNmxrzNptlp+hgxnG9Y2THYvHrvmXIuHUyNAWO6Q+F4rm4/bmTOukprXEyF/j4qsC2A==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.3.3:
+    resolution: {integrity: sha512-tuRTx1nQ/yVw83cwJBo9F+njGUgMn3UHQycreWHB8XsStvvAh1AthbI8/4IpKnFaF58F+iSiHejYOlMQ/eq83g==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5943,6 +6401,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   pnpm-workspace-yaml@1.6.1:
     resolution: {integrity: sha512-yTeZntGWi8m9WNuhoVsP0DpFc4sC1U0+rr/qR6Zi9n2g3sxXY+JfccjXjjruNz96tM8I09yaJUA86doRnNLkbg==}
 
@@ -5962,6 +6430,10 @@ packages:
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -6266,6 +6738,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6306,6 +6783,15 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.35.4:
+    resolution: {integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7364,6 +7850,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -7514,39 +8005,84 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.3':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.3':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.3':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -7554,9 +8090,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.3
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -7564,9 +8110,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -7574,9 +8130,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.3
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -7584,9 +8150,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -7594,13 +8170,32 @@ snapshots:
       '@emnapi/runtime': 1.10.0
     optional: true
 
+  '@img/sharp-wasm32@0.35.4':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.4':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.4
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.4':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.4':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.4':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -7679,30 +8274,112 @@ snapshots:
       '@neodrag/core': 3.0.0-next.11
       solid-js: 1.9.13
 
+  '@next/env@15.5.24': {}
+
+  '@next/env@16.0.11': {}
+
   '@next/env@16.2.6': {}
 
+  '@next/env@16.3.3': {}
+
+  '@next/playwright@16.3.3(@playwright/test@1.62.1)':
+    optionalDependencies:
+      '@playwright/test': 1.62.1
+
+  '@next/swc-darwin-arm64@15.5.24':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.0.11':
+    optional: true
+
   '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.3.3':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.24':
+    optional: true
+
+  '@next/swc-darwin-x64@16.0.11':
     optional: true
 
   '@next/swc-darwin-x64@16.2.6':
     optional: true
 
+  '@next/swc-darwin-x64@16.3.3':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.24':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.0.11':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.3.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.24':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.0.11':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
+  '@next/swc-linux-arm64-musl@16.3.3':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.24':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.0.11':
+    optional: true
+
   '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.3.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.24':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.0.11':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
+  '@next/swc-linux-x64-musl@16.3.3':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.24':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.0.11':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.3.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.24':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.0.11':
+    optional: true
+
   '@next/swc-win32-x64-msvc@16.2.6':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.3.3':
     optional: true
 
   '@noble/hashes@1.8.0': {}
@@ -8041,6 +8718,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8607,6 +9288,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -8767,7 +9452,7 @@ snapshots:
       semver: 7.8.1
       yaml: 2.8.3
 
-  '@tanstack/query-core@5.101.0': {}
+  '@tanstack/query-core@5.102.7': {}
 
   '@tanstack/react-devtools@0.10.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.13)':
     dependencies:
@@ -8782,9 +9467,9 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-query@5.101.0(react@19.2.6)':
+  '@tanstack/react-query@5.102.7(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.101.0
+      '@tanstack/query-core': 5.102.7
       react: 19.2.6
 
   '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -8809,12 +9494,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.6))(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-router-ssr-query@1.167.2(@tanstack/query-core@5.102.7)(@tanstack/react-query@5.102.7(react@19.2.6))(@tanstack/react-router@1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@tanstack/router-core@1.171.27)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/query-core': 5.101.0
-      '@tanstack/react-query': 5.101.0(react@19.2.6)
+      '@tanstack/query-core': 5.102.7
+      '@tanstack/react-query': 5.102.7(react@19.2.6)
       '@tanstack/react-router': 1.170.32(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/router-ssr-query-core': 1.169.1(@tanstack/query-core@5.101.0)(@tanstack/router-core@1.171.27)
+      '@tanstack/router-ssr-query-core': 1.169.2(@tanstack/query-core@5.102.7)(@tanstack/router-core@1.171.27)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -9206,9 +9891,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.0)(@tanstack/router-core@1.171.27)':
+  '@tanstack/router-ssr-query-core@1.169.2(@tanstack/query-core@5.102.7)(@tanstack/router-core@1.171.27)':
     dependencies:
-      '@tanstack/query-core': 5.101.0
+      '@tanstack/query-core': 5.102.7
       '@tanstack/router-core': 1.171.27
 
   '@tanstack/router-utils@1.162.1(supports-color@7.2.0)':
@@ -9832,10 +10517,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vercel/analytics@2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))':
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(svelte@5.56.0)(vue@3.5.35(typescript@7.0.2))':
     optionalDependencies:
       '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0)(typescript@7.0.2)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       svelte: 5.56.0
       vue: 3.5.35(typescript@7.0.2)
@@ -9942,7 +10627,7 @@ snapshots:
       '@vue/shared': 3.5.35
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.35':
@@ -10962,10 +11647,13 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3):
+  fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -10992,21 +11680,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.15
       lucide-react: 1.17.0(react@19.2.6)
-      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  fumadocs-mdx@15.0.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rolldown@1.0.3)(supports-color@7.2.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0(supports-color@7.2.0)
       picocolors: 1.1.1
@@ -11022,19 +11710,19 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.15
-      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       rolldown: 1.0.3
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.2.0(b4a625e5e99ec7f2a6e049efc2c17627):
+  fumadocs-twoslash@3.2.0(056b6d17c4e5ae10ed9baa01b99cdd99):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@shikijs/twoslash': 4.1.0(supports-color@7.2.0)(typescript@7.0.2)
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
-      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
+      fumadocs-ui: 16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       mdast-util-to-hast: 13.2.1
@@ -11050,7 +11738,7 @@ snapshots:
       - supports-color
       - typescript
 
-  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
+  fumadocs-ui@16.9.3(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(fumadocs-core@16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.0)(tailwindcss@4.3.0)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11064,7 +11752,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.15)(react@19.2.6)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
+      fumadocs-core: 16.9.3(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(@tanstack/react-router@1.170.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@1.17.0(react@19.2.6))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@7.2.0)(zod@4.4.3)
       lucide-react: 1.17.0(react@19.2.6)
       motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11079,7 +11767,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.15
-      next: 16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@tailwindcss/oxide'
@@ -11616,7 +12304,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.5
 
   markdown-extensions@2.0.0: {}
 
@@ -12155,6 +12843,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@3.3.18: {}
+
   negotiator@1.0.0: {}
 
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -12162,7 +12852,55 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@15.5.24(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 15.5.24
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001793
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.24
+      '@next/swc-darwin-x64': 15.5.24
+      '@next/swc-linux-arm64-gnu': 15.5.24
+      '@next/swc-linux-arm64-musl': 15.5.24
+      '@next/swc-linux-x64-gnu': 15.5.24
+      '@next/swc-linux-x64-musl': 15.5.24
+      '@next/swc-win32-arm64-msvc': 15.5.24
+      '@next/swc-win32-x64-msvc': 15.5.24
+      '@playwright/test': 1.62.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.0.11(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.0.11
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001793
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.0.11
+      '@next/swc-darwin-x64': 16.0.11
+      '@next/swc-linux-arm64-gnu': 16.0.11
+      '@next/swc-linux-arm64-musl': 16.0.11
+      '@next/swc-linux-x64-gnu': 16.0.11
+      '@next/swc-linux-x64-musl': 16.0.11
+      '@next/swc-win32-arm64-msvc': 16.0.11
+      '@next/swc-win32-x64-msvc': 16.0.11
+      '@playwright/test': 1.62.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.6(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -12181,9 +12919,36 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(@types/node@25.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.3.3
+      '@swc/helpers': 0.5.23
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      postcss: 8.5.23
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@7.2.0))(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.3.3
+      '@next/swc-darwin-x64': 16.3.3
+      '@next/swc-linux-arm64-gnu': 16.3.3
+      '@next/swc-linux-arm64-musl': 16.3.3
+      '@next/swc-linux-x64-gnu': 16.3.3
+      '@next/swc-linux-x64-musl': 16.3.3
+      '@next/swc-win32-arm64-msvc': 16.3.3
+      '@next/swc-win32-x64-msvc': 16.3.3
+      '@playwright/test': 1.62.1
+      sharp: 0.35.4(@types/node@25.9.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   nf3@0.3.17: {}
@@ -12490,6 +13255,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pnpm-workspace-yaml@1.6.1:
     dependencies:
       yaml: 2.9.0
@@ -12515,6 +13288,12 @@ snapshots:
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12848,6 +13627,8 @@ snapshots:
 
   semver@7.8.1: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -12921,6 +13702,40 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  sharp@0.35.4(@types/node@25.9.1):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.4
+      '@img/sharp-darwin-x64': 0.35.4
+      '@img/sharp-freebsd-wasm32': 0.35.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.3
+      '@img/sharp-libvips-darwin-x64': 1.3.3
+      '@img/sharp-libvips-linux-arm': 1.3.3
+      '@img/sharp-libvips-linux-arm64': 1.3.3
+      '@img/sharp-libvips-linux-ppc64': 1.3.3
+      '@img/sharp-libvips-linux-riscv64': 1.3.3
+      '@img/sharp-libvips-linux-s390x': 1.3.3
+      '@img/sharp-libvips-linux-x64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.3
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.3
+      '@img/sharp-linux-arm': 0.35.4
+      '@img/sharp-linux-arm64': 0.35.4
+      '@img/sharp-linux-ppc64': 0.35.4
+      '@img/sharp-linux-riscv64': 0.35.4
+      '@img/sharp-linux-s390x': 0.35.4
+      '@img/sharp-linux-x64': 0.35.4
+      '@img/sharp-linuxmusl-arm64': 0.35.4
+      '@img/sharp-linuxmusl-x64': 0.35.4
+      '@img/sharp-webcontainers-wasm32': 0.35.4
+      '@img/sharp-win32-arm64': 0.35.4
+      '@img/sharp-win32-ia32': 0.35.4
+      '@img/sharp-win32-x64': 0.35.4
+      '@types/node': 25.9.1
     optional: true
 
   shebang-command@2.0.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - permix
+  - permix/test/next
   - docs
   - examples/*
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-shellEmulator: true
 packages:
   - permix
   - docs
@@ -7,3 +6,33 @@ allowBuilds:
   better-sqlite3: true
   esbuild: false
   sharp: false
+catalog:
+  '@types/node': ^25.9.1
+  '@types/react': ^19.2.15
+  '@types/react-dom': ^19.2.3
+  '@vitejs/plugin-react': ^6.0.2
+  oxfmt: ^0.64.0
+  oxlint: ^1.79.0
+  oxlint-tsgolint: ^7.0.2001
+  react: ^19.2.6
+  react-dom: ^19.2.6
+  tsx: ^4.22.4
+  turbo: 2.10.12
+  typescript: 7.0.2
+  ultracite: ^7.10.6
+  vite: ^8.0.16
+  vitest: ^4.1.8
+catalogs:
+  typescript-classic:
+    typescript59: npm:typescript@5.9.3
+    typescript6: npm:@typescript/typescript6@6.0.2
+catalogMode: strict
+saveWorkspaceProtocol: rolling
+strictPeerDependencies: true
+peerDependencyRules:
+  allowedVersions:
+    typescript: '*'
+    drizzle-orm>effect: '*'
+publicHoistPattern:
+  - '@typescript/*'
+shellEmulator: true

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,37 @@
 {
-  "$schema": "./node_modules/turbo/schema.json",
+  "$schema": "https://v2-10-12.turborepo.dev/schema.json",
+  "ui": "tui",
+  "concurrency": "100%",
+  "cacheMaxAge": "14d",
+  "cacheMaxSize": "10GB",
   "tasks": {
+    "transit": {
+      "dependsOn": ["^transit"]
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$"],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**",
+        "!.next/dev/**",
+        ".source/**",
+        ".output/**"
+      ]
+    },
     "check-types": {
-      "cache": false
+      "dependsOn": ["transit", "permix#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        {
+          "mode": "jit",
+          "globs": [".source/**"]
+        }
+      ]
+    },
+    "test": {
+      "dependsOn": ["transit", "permix#build"]
     }
   }
 }


### PR DESCRIPTION
## Summary

`createPermix` from `permix/next` now takes a sync or async rules resolver. React `cache()` memoizes one Promise of a fully initialized instance per RSC request, so layout and page callers no longer race `setup()` on a shared mutable helper.

Async Server Components `await permix.check()` / `await permix.getPermix()`. Non-async Server Components call `permix.usePermix()` (React `use()`), so `check()` stays synchronous at the call site. Layouts and pages can stay synchronous; permission and session work moves into feature components behind page-owned Suspense, which is what Cache Components needs.

This is a breaking change for `permix/next`: `setup()`, sync `check()`, `get()`, `hook()`, and `hookOnce()` are gone. Route Handlers and Server Actions still must `createPermix()` + `setup()` a core instance per invocation — they do not share the RSC `cache()` identity. Peer range is Next.js 15+.

The Next example is rebuilt around that split (public vs session factories, client `createPermix` from `permix/react`, Cache Components + partial prefetching). Playwright covers Next 15.5, 16.0, and 16.3 (PPR) in CI.

## Stacking

Depends on #56 (React factory) which itself depends on #54. Until those merge, GitHub will also list their commits. Review the Next-only diff here: https://github.com/martijn00/permix/compare/feat/react-create-permix...feat/next-resolver-cache-components

## Test plan

- [ ] `pnpm --filter permix exec vitest run src/next`
- [ ] `pnpm test:next` (Playwright matrix; needs Chromium)
- [ ] Smoke the Next example: public read prerenders, session create stays behind Suspense, login/logout updates client checks

