### PR TITLE
fix: rehydrate Svelte on state change and run UI checks through the instance

### DIFF
--- a/permix/src/svelte/PermixHydrate.svelte
+++ b/permix/src/svelte/PermixHydrate.svelte
@@ -8,7 +8,11 @@ const { state, children }: { state: DehydratedState<any>, children: Snippet } = 
 
 const context = usePermixContext()
 
-untrack(() => context.permix.hydrate(state))
+// Hydrate before children render, and again whenever `state` changes.
+$effect.pre(() => {
+  const next = state
+  untrack(() => context.permix.hydrate(next))
+})
 </script>
 
 {@render children()}

--- a/permix/src/svelte/components.test.ts
+++ b/permix/src/svelte/components.test.ts
@@ -35,6 +35,22 @@ describe('components', () => {
     expect(getByTestId('create')).toHaveTextContent('true')
   })
 
+  it('should rehydrate when state changes', async () => {
+    const permix = createPermix<{
+      post: ['create', 'read']
+    }>()
+
+    const { getByTestId, rerender } = render(HydrateApp, {
+      props: { permix, state: { post: { create: true, read: false } } },
+    })
+
+    expect(getByTestId('create')).toHaveTextContent('true')
+
+    await rerender({ permix, state: { post: { create: false, read: false } } })
+
+    expect(getByTestId('create')).toHaveTextContent('false')
+  })
+
   it('should work with Check component', () => {
     const permix = createPermix<{
       post: ['create']


### PR DESCRIPTION
## Summary

- stacks on [#70](https://github.com/letstri/permix/pull/70); review the last commit(s) once #70 merges
- UI `check()` uses overlay rules only while the instance is not ready, then goes through `instance.check()` so hooks and Standard Schema `validate: 'deny'` run
- Svelte `PermixHydrate` rehydrates when `state` changes; Vue `Check` caches a computed boolean
- README, getting started, and CONTRIBUTING document that core `setup()` is not request-safe, and that `pnpm verify:full` includes Playwright
- overlapping `setup()` last-write-wins is characterized until immutable instances land

## Test plan

- [x] `pnpm exec vitest run src/core src/react src/vue src/solid src/svelte src/standard-schema`
- [x] `pnpm test`
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm --filter permix size:compare`

## Checklist

- [x] docs updated (`docs/content/docs/index.mdx`, `README.md`, `CONTRIBUTING.md`)
- [x] `permix/skills/` aligned for the request-safety note
- [x] added tests for Svelte rehydrate, UI check hooks, Standard Schema deny hooks, and concurrent `setup()` last-write-wins


Made with [Cursor](https://cursor.com)